### PR TITLE
Changed Responsibility for EngineId

### DIFF
--- a/junit-commons/src/main/java/org/junit/gen5/commons/util/ReflectionUtils.java
+++ b/junit-commons/src/main/java/org/junit/gen5/commons/util/ReflectionUtils.java
@@ -184,7 +184,7 @@ public class ReflectionUtils {
 		return true;
 	}
 
-	public static Class[] findAllClassesInIackage(String packageName) {
+	public static Class[] findAllClassesInPackage(String packageName) {
 		return new ReflectionPackage(packageName).findAllClasses();
 	}
 

--- a/junit-commons/src/test/java/org/junit/gen5/commons/util/FindClassesInPackageTest.java
+++ b/junit-commons/src/test/java/org/junit/gen5/commons/util/FindClassesInPackageTest.java
@@ -12,7 +12,6 @@ package org.junit.gen5.commons.util;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -21,7 +20,7 @@ public class FindClassesInPackageTest {
 
 	@Test
 	public void findAllClassesInThisPackage() throws IOException, ClassNotFoundException {
-		Class[] classes = ReflectionUtils.findAllClassesInIackage("org.junit.gen5.commons");
+		Class[] classes = ReflectionUtils.findAllClassesInPackage("org.junit.gen5.commons");
 		//		for(Class clazz : classes) {
 		//			System.out.println(clazz.getName());
 		//		}

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/TestEngine.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/TestEngine.java
@@ -18,7 +18,7 @@ public interface TestEngine {
 		return getClass().getCanonicalName();
 	}
 
-	Collection<TestDescriptor> discoverTests(TestPlanSpecification specification, EngineDescriptor engineDescriptor);
+	Collection<TestDescriptor> discoverTests(TestPlanSpecification specification);
 
 	default boolean supports(TestDescriptor testDescriptor) {
 		return testDescriptor.getUniqueId().startsWith(getId());

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/Launcher.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/Launcher.java
@@ -38,10 +38,8 @@ public class Launcher {
 	public TestPlan discover(TestPlanSpecification specification) {
 		TestPlan testPlan = new TestPlan();
 		for (TestEngine testEngine : lookupAllTestEngines()) {
-			EngineDescriptor engineDescriptor = new EngineDescriptor(testEngine);
-			Collection<TestDescriptor> testDescriptors = testEngine.discoverTests(specification, engineDescriptor);
+			Collection<TestDescriptor> testDescriptors = testEngine.discoverTests(specification);
 			if (!testDescriptors.isEmpty()) {
-				testPlan.addTestDescriptor(engineDescriptor);
 				testPlan.addTestDescriptors(testDescriptors);
 			}
 		}

--- a/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/JUnit4TestEngine.java
+++ b/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/JUnit4TestEngine.java
@@ -45,9 +45,11 @@ public class JUnit4TestEngine implements TestEngine {
 	}
 
 	@Override
-	public Collection<TestDescriptor> discoverTests(TestPlanSpecification specification,
-			EngineDescriptor engineDescriptor) {
+	public Collection<TestDescriptor> discoverTests(TestPlanSpecification specification) {
 		Set<TestDescriptor> result = new LinkedHashSet<>();
+		EngineDescriptor engineDescriptor = new EngineDescriptor(this);
+		result.add(engineDescriptor);
+
 		for (TestPlanSpecificationElement element : specification) {
 			if (element instanceof ClassNameSpecification) {
 				String className = ((ClassNameSpecification) element).getClassName();

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
@@ -39,9 +39,11 @@ public class JUnit5TestEngine implements TestEngine {
 	}
 
 	@Override
-	public List<TestDescriptor> discoverTests(TestPlanSpecification specification, EngineDescriptor engineDescriptor) {
+	public List<TestDescriptor> discoverTests(TestPlanSpecification specification) {
 		// TODO Avoid redundant creation of TestDescriptors during this phase
 		Set<TestDescriptor> testDescriptors = new LinkedHashSet<>();
+		EngineDescriptor engineDescriptor = new EngineDescriptor(this);
+		testDescriptors.add(engineDescriptor);
 		resolveSpecification(specification, engineDescriptor, testDescriptors);
 		return new ArrayList<>(testDescriptors);
 	}
@@ -57,8 +59,7 @@ public class JUnit5TestEngine implements TestEngine {
 
 	@Override
 	public boolean supports(TestDescriptor testDescriptor) {
-		// TODO Consider creating a superclass or marker interface for JUnit 5 test
-		// descriptors.
+		// TODO Consider creating a superclass or marker interface for JUnit 5 test descriptors.
 		return testDescriptor.getUniqueId().startsWith(getId());
 	}
 

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
@@ -37,19 +37,19 @@ public class JUnit5TestEngine implements TestEngine {
 	// TODO Consider using class names for engine IDs.
 	private static final String JUNIT5_ENGINE_ID = "junit5";
 
-	public static JUnit5Testable fromUniqueId(String uniqueId) {
+	public JUnit5Testable fromUniqueId(String uniqueId) {
 		return new JUnit5TestableFactory().fromUniqueId(uniqueId, JUNIT5_ENGINE_ID);
 	}
 
-	public static JUnit5Testable fromClassName(String className) {
+	public JUnit5Testable fromClassName(String className) {
 		return new JUnit5TestableFactory().fromClassName(className, JUNIT5_ENGINE_ID);
 	}
 
-	public static JUnit5Testable fromClass(Class<?> clazz) {
+	public JUnit5Testable fromClass(Class<?> clazz) {
 		return new JUnit5TestableFactory().fromClass(clazz, JUNIT5_ENGINE_ID);
 	}
 
-	public static JUnit5Testable fromMethod(Method testMethod, Class<?> clazz) {
+	public JUnit5Testable fromMethod(Method testMethod, Class<?> clazz) {
 		return new JUnit5TestableFactory().fromMethod(testMethod, clazz, JUNIT5_ENGINE_ID);
 	}
 
@@ -66,7 +66,7 @@ public class JUnit5TestEngine implements TestEngine {
 		EngineDescriptor engineDescriptor = new EngineDescriptor(this);
 		testDescriptors.add(engineDescriptor);
 
-		SpecificationResolver resolver = new SpecificationResolver(testDescriptors, engineDescriptor);
+		SpecificationResolver resolver = new SpecificationResolver(this, testDescriptors, engineDescriptor);
 		for (TestPlanSpecificationElement element : specification) {
 			resolver.resolveElement(element);
 		}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
@@ -26,25 +26,26 @@ import org.junit.gen5.engine.junit5.execution.TestExecutionNode;
 import org.junit.gen5.engine.junit5.execution.TestExecutionNodeResolver;
 
 public class JUnit5TestEngine implements TestEngine {
+
 	// TODO Consider using class names for engine IDs.
 	public static final String JUNIT5_ENGINE_ID = "junit5";
 
-	private final JUnit5TestableFactory JUnit5TestableFactory = new JUnit5TestableFactory(this);
+	private final JUnit5TestableFactory testableFactory = new JUnit5TestableFactory(this);
 
 	public JUnit5Testable fromUniqueId(String uniqueId) {
-		return JUnit5TestableFactory.fromUniqueId(uniqueId);
+		return testableFactory.fromUniqueId(uniqueId);
 	}
 
 	public JUnit5Testable fromClassName(String className) {
-		return JUnit5TestableFactory.fromClassName(className);
+		return testableFactory.fromClassName(className);
 	}
 
 	public JUnit5Testable fromClass(Class<?> clazz) {
-		return JUnit5TestableFactory.fromClass(clazz);
+		return testableFactory.fromClass(clazz);
 	}
 
 	public JUnit5Testable fromMethod(Method testMethod, Class<?> clazz) {
-		return JUnit5TestableFactory.fromMethod(testMethod, clazz);
+		return testableFactory.fromMethod(testMethod, clazz);
 	}
 
 	@Override

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
@@ -13,13 +13,7 @@ package org.junit.gen5.engine.junit5;
 import static java.util.stream.Collectors.toList;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import org.junit.gen5.engine.EngineDescriptor;
 import org.junit.gen5.engine.EngineExecutionContext;
@@ -27,30 +21,30 @@ import org.junit.gen5.engine.TestDescriptor;
 import org.junit.gen5.engine.TestEngine;
 import org.junit.gen5.engine.TestPlanSpecification;
 import org.junit.gen5.engine.TestPlanSpecificationElement;
-import org.junit.gen5.engine.junit5.descriptor.JUnit5Testable;
-import org.junit.gen5.engine.junit5.descriptor.JUnit5TestableFactory;
-import org.junit.gen5.engine.junit5.descriptor.SpecificationResolver;
+import org.junit.gen5.engine.junit5.descriptor.*;
 import org.junit.gen5.engine.junit5.execution.TestExecutionNode;
 import org.junit.gen5.engine.junit5.execution.TestExecutionNodeResolver;
 
 public class JUnit5TestEngine implements TestEngine {
 	// TODO Consider using class names for engine IDs.
-	private static final String JUNIT5_ENGINE_ID = "junit5";
+	public static final String JUNIT5_ENGINE_ID = "junit5";
+
+	private final JUnit5TestableFactory JUnit5TestableFactory = new JUnit5TestableFactory(this);
 
 	public JUnit5Testable fromUniqueId(String uniqueId) {
-		return new JUnit5TestableFactory().fromUniqueId(uniqueId, JUNIT5_ENGINE_ID);
+		return JUnit5TestableFactory.fromUniqueId(uniqueId);
 	}
 
 	public JUnit5Testable fromClassName(String className) {
-		return new JUnit5TestableFactory().fromClassName(className, JUNIT5_ENGINE_ID);
+		return JUnit5TestableFactory.fromClassName(className);
 	}
 
 	public JUnit5Testable fromClass(Class<?> clazz) {
-		return new JUnit5TestableFactory().fromClass(clazz, JUNIT5_ENGINE_ID);
+		return JUnit5TestableFactory.fromClass(clazz);
 	}
 
 	public JUnit5Testable fromMethod(Method testMethod, Class<?> clazz) {
-		return new JUnit5TestableFactory().fromMethod(testMethod, clazz, JUNIT5_ENGINE_ID);
+		return JUnit5TestableFactory.fromMethod(testMethod, clazz);
 	}
 
 	@Override

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
@@ -12,6 +12,7 @@ package org.junit.gen5.engine.junit5;
 
 import static java.util.stream.Collectors.toList;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -26,35 +27,51 @@ import org.junit.gen5.engine.TestDescriptor;
 import org.junit.gen5.engine.TestEngine;
 import org.junit.gen5.engine.TestPlanSpecification;
 import org.junit.gen5.engine.TestPlanSpecificationElement;
+import org.junit.gen5.engine.junit5.descriptor.JUnit5Testable;
+import org.junit.gen5.engine.junit5.descriptor.JUnit5TestableFactory;
 import org.junit.gen5.engine.junit5.descriptor.SpecificationResolver;
 import org.junit.gen5.engine.junit5.execution.TestExecutionNode;
 import org.junit.gen5.engine.junit5.execution.TestExecutionNodeResolver;
 
 public class JUnit5TestEngine implements TestEngine {
+	// TODO Consider using class names for engine IDs.
+	private static final String JUNIT5_ENGINE_ID = "junit5";
+
+	public static JUnit5Testable fromUniqueId(String uniqueId) {
+		return new JUnit5TestableFactory().fromUniqueId(uniqueId, JUNIT5_ENGINE_ID);
+	}
+
+	public static JUnit5Testable fromClassName(String className) {
+		return new JUnit5TestableFactory().fromClassName(className, JUNIT5_ENGINE_ID);
+	}
+
+	public static JUnit5Testable fromClass(Class<?> clazz) {
+		return new JUnit5TestableFactory().fromClass(clazz, JUNIT5_ENGINE_ID);
+	}
+
+	public static JUnit5Testable fromMethod(Method testMethod, Class<?> clazz) {
+		return new JUnit5TestableFactory().fromMethod(testMethod, clazz, JUNIT5_ENGINE_ID);
+	}
 
 	@Override
 	public String getId() {
-		// TODO Consider using class names for engine IDs.
-		return "junit5";
+		return JUNIT5_ENGINE_ID;
 	}
 
 	@Override
 	public List<TestDescriptor> discoverTests(TestPlanSpecification specification) {
 		// TODO Avoid redundant creation of TestDescriptors during this phase
 		Set<TestDescriptor> testDescriptors = new LinkedHashSet<>();
+
 		EngineDescriptor engineDescriptor = new EngineDescriptor(this);
 		testDescriptors.add(engineDescriptor);
-		resolveSpecification(specification, engineDescriptor, testDescriptors);
-		return new ArrayList<>(testDescriptors);
-	}
 
-	// Isolated this step to allow easier experimentation / branching / pull requesting
-	private void resolveSpecification(TestPlanSpecification specification, EngineDescriptor engineDescriptor,
-			Set<TestDescriptor> testDescriptors) {
 		SpecificationResolver resolver = new SpecificationResolver(testDescriptors, engineDescriptor);
 		for (TestPlanSpecificationElement element : specification) {
 			resolver.resolveElement(element);
 		}
+
+		return new ArrayList<>(testDescriptors);
 	}
 
 	@Override

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Class.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Class.java
@@ -17,7 +17,7 @@ public class JUnit5Class extends JUnit5Testable {
 
 	private final Class<?> javaClass;
 
-	JUnit5Class(String uniqueId, Class<?> javaClass) {
+	public JUnit5Class(String uniqueId, Class<?> javaClass) {
 		super(uniqueId);
 		this.javaClass = javaClass;
 	}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Method.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Method.java
@@ -20,7 +20,7 @@ public class JUnit5Method extends JUnit5Testable {
 	private final Class<?> containerClass;
 	private final Method javaMethod;
 
-	JUnit5Method(String uniqueId, Method javaElement, Class<?> containerClass) {
+	public JUnit5Method(String uniqueId, Method javaElement, Class<?> containerClass) {
 		super(uniqueId);
 		this.javaMethod = javaElement;
 		this.containerClass = containerClass;

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Testable.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Testable.java
@@ -14,22 +14,6 @@ import java.lang.reflect.Method;
 
 public abstract class JUnit5Testable {
 
-	public static JUnit5Testable fromUniqueId(String uniqueId, String engineId) {
-		return new JUnit5TestableFactory().fromUniqueId(uniqueId, engineId);
-	}
-
-	public static JUnit5Testable fromClassName(String className, String engineId) {
-		return new JUnit5TestableFactory().fromClassName(className, engineId);
-	}
-
-	public static JUnit5Testable fromClass(Class<?> clazz, String engineId) {
-		return new JUnit5TestableFactory().fromClass(clazz, engineId);
-	}
-
-	public static JUnit5Testable fromMethod(Method testMethod, Class<?> clazz, String engineId) {
-		return new JUnit5TestableFactory().fromMethod(testMethod, clazz, engineId);
-	}
-
 	private final String uniqueId;
 
 	JUnit5Testable(String uniqueId) {

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestableFactory.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestableFactory.java
@@ -1,8 +1,14 @@
-package org.junit.gen5.engine.junit5.descriptor;
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 
-import org.junit.gen5.commons.util.Preconditions;
-import org.junit.gen5.commons.util.ReflectionUtils;
-import org.junit.gen5.engine.junit5.JUnit5TestEngine;
+package org.junit.gen5.engine.junit5.descriptor;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
@@ -12,151 +18,155 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.junit.gen5.commons.util.Preconditions;
+import org.junit.gen5.commons.util.ReflectionUtils;
+import org.junit.gen5.engine.junit5.JUnit5TestEngine;
+
 public class JUnit5TestableFactory {
-  private static final String SEPARATORS = ":$#";
-  private final JUnit5TestEngine testEngine;
 
-  public JUnit5TestableFactory(JUnit5TestEngine testEngine) {
-    this.testEngine = testEngine;
-  }
+	private static final String SEPARATORS = ":$#";
+	private final JUnit5TestEngine testEngine;
 
-  public JUnit5Testable fromUniqueId(String uniqueId) {
-    Preconditions.notEmpty(uniqueId, "uniqueId must not be empty");
-    List<String> parts = split(uniqueId);
-    Preconditions.condition(parts.remove(0).equals(testEngine.getId()), "uniqueId must start with engineId");
-    return createElement(uniqueId, parts);
-  }
+	public JUnit5TestableFactory(JUnit5TestEngine testEngine) {
+		this.testEngine = testEngine;
+	}
 
-  private List<String> split(String uniqueId) {
-    List<String> parts = new ArrayList<String>();
-    String currentPart = "";
-    for (char c : uniqueId.toCharArray()) {
-      if (SEPARATORS.contains(Character.toString(c))) {
-        parts.add(currentPart);
-        currentPart = "";
-      }
-      currentPart += c;
-    }
-    parts.add(currentPart);
-    return parts;
-  }
+	public JUnit5Testable fromUniqueId(String uniqueId) {
+		Preconditions.notEmpty(uniqueId, "uniqueId must not be empty");
+		List<String> parts = split(uniqueId);
+		Preconditions.condition(parts.remove(0).equals(testEngine.getId()), "uniqueId must start with engineId");
+		return createElement(uniqueId, parts);
+	}
 
-  private JUnit5Testable createElement(String uniqueId, List<String> parts) {
-    AnnotatedElement currentJavaElement = null;
-    Class<?> currentJavaContainer = null;
-    String head = parts.remove(0);
-    while (true) {
-      switch (head.charAt(0)) {
-        case ':':
-          currentJavaElement = findTopLevelClass(head);
-          break;
-        case '$':
-          currentJavaContainer = (Class<?>) currentJavaElement;
-          currentJavaElement = findNestedClass(head, (Class<?>) currentJavaElement);
-          break;
-        case '#':
-          currentJavaContainer = (Class<?>) currentJavaElement;
-          currentJavaElement = findMethod(head, currentJavaContainer, uniqueId);
-          break;
-        default:
-          currentJavaContainer = null;
-          currentJavaElement = null;
-      }
+	private List<String> split(String uniqueId) {
+		List<String> parts = new ArrayList<String>();
+		String currentPart = "";
+		for (char c : uniqueId.toCharArray()) {
+			if (SEPARATORS.contains(Character.toString(c))) {
+				parts.add(currentPart);
+				currentPart = "";
+			}
+			currentPart += c;
+		}
+		parts.add(currentPart);
+		return parts;
+	}
 
-      if (currentJavaElement == null) {
-        throwCannotResolveUniqueIdException(uniqueId, head);
-      }
-      if (parts.isEmpty())
-        break;
-      head = parts.remove(0);
-    }
-    if (currentJavaElement instanceof Method) {
-      return new JUnit5Method(uniqueId, (Method) currentJavaElement, currentJavaContainer);
-    }
-    if (currentJavaElement instanceof Class) {
-      return new JUnit5Class(uniqueId, (Class<?>) currentJavaElement);
-    }
-    return null; //cannot happen
-  }
+	private JUnit5Testable createElement(String uniqueId, List<String> parts) {
+		AnnotatedElement currentJavaElement = null;
+		Class<?> currentJavaContainer = null;
+		String head = parts.remove(0);
+		while (true) {
+			switch (head.charAt(0)) {
+				case ':':
+					currentJavaElement = findTopLevelClass(head);
+					break;
+				case '$':
+					currentJavaContainer = (Class<?>) currentJavaElement;
+					currentJavaElement = findNestedClass(head, (Class<?>) currentJavaElement);
+					break;
+				case '#':
+					currentJavaContainer = (Class<?>) currentJavaElement;
+					currentJavaElement = findMethod(head, currentJavaContainer, uniqueId);
+					break;
+				default:
+					currentJavaContainer = null;
+					currentJavaElement = null;
+			}
 
-  private Method findMethod(String methodSpecPart, Class<?> clazz, String uniqueId) {
-    int startParams = methodSpecPart.indexOf('(');
-    String methodName = methodSpecPart.substring(1, startParams);
-    int endParams = methodSpecPart.lastIndexOf(')');
-    String paramsPart = methodSpecPart.substring(startParams + 1, endParams);
-    Class<?>[] parameterTypes = findParameterTypes(paramsPart, uniqueId);
-    return findMethod(clazz, methodName, parameterTypes);
-  }
+			if (currentJavaElement == null) {
+				throwCannotResolveUniqueIdException(uniqueId, head);
+			}
+			if (parts.isEmpty())
+				break;
+			head = parts.remove(0);
+		}
+		if (currentJavaElement instanceof Method) {
+			return new JUnit5Method(uniqueId, (Method) currentJavaElement, currentJavaContainer);
+		}
+		if (currentJavaElement instanceof Class) {
+			return new JUnit5Class(uniqueId, (Class<?>) currentJavaElement);
+		}
+		return null; //cannot happen
+	}
 
-  private Class<?>[] findParameterTypes(String paramsPart, String uniqueId) {
-    if (paramsPart.isEmpty()) {
-      return new Class<?>[0];
-    }
-    List<Class<?>> types = Arrays.stream(paramsPart.split(",")).map(typeName -> {
-      Optional<Class<?>> aClass = ReflectionUtils.loadClass(typeName);
-      if (aClass.isPresent())
-        return aClass.get();
-      else {
-        throwCannotResolveUniqueIdException(uniqueId, paramsPart);
-        return null; //cannot happen
-      }
-    }).collect(Collectors.toList());
-    return types.toArray(new Class<?>[types.size()]);
-  }
+	private Method findMethod(String methodSpecPart, Class<?> clazz, String uniqueId) {
+		int startParams = methodSpecPart.indexOf('(');
+		String methodName = methodSpecPart.substring(1, startParams);
+		int endParams = methodSpecPart.lastIndexOf(')');
+		String paramsPart = methodSpecPart.substring(startParams + 1, endParams);
+		Class<?>[] parameterTypes = findParameterTypes(paramsPart, uniqueId);
+		return findMethod(clazz, methodName, parameterTypes);
+	}
 
-  private Method findMethod(Class<?> clazz, String methodName, Class<?>[] parameterTypes) {
-    return ReflectionUtils.findMethod(clazz, methodName, parameterTypes).orElseThrow(
-        () -> new IllegalArgumentException(String.format("No method with 'name' %s and paramter types '%s'",
-            methodName, Arrays.toString(parameterTypes))));
-  }
+	private Class<?>[] findParameterTypes(String paramsPart, String uniqueId) {
+		if (paramsPart.isEmpty()) {
+			return new Class<?>[0];
+		}
+		List<Class<?>> types = Arrays.stream(paramsPart.split(",")).map(typeName -> {
+			Optional<Class<?>> aClass = ReflectionUtils.loadClass(typeName);
+			if (aClass.isPresent())
+				return aClass.get();
+			else {
+				throwCannotResolveUniqueIdException(uniqueId, paramsPart);
+				return null; //cannot happen
+			}
+		}).collect(Collectors.toList());
+		return types.toArray(new Class<?>[types.size()]);
+	}
 
-  private Class<?> findNestedClass(String nameExtension, Class<?> containerClass) {
-    String fullClassName = containerClass.getName() + nameExtension;
-    return classByName(fullClassName);
-  }
+	private Method findMethod(Class<?> clazz, String methodName, Class<?>[] parameterTypes) {
+		return ReflectionUtils.findMethod(clazz, methodName, parameterTypes).orElseThrow(
+			() -> new IllegalArgumentException(String.format("No method with 'name' %s and paramter types '%s'",
+				methodName, Arrays.toString(parameterTypes))));
+	}
 
-  private Class<?> findTopLevelClass(String classNamePart) {
-    String className = classNamePart.substring(1);
-    return classByName(className);
-  }
+	private Class<?> findNestedClass(String nameExtension, Class<?> containerClass) {
+		String fullClassName = containerClass.getName() + nameExtension;
+		return classByName(fullClassName);
+	}
 
-  private Class<?> classByName(String className) {
-    return ReflectionUtils.loadClass(className).orElse(null);
-  }
+	private Class<?> findTopLevelClass(String classNamePart) {
+		String className = classNamePart.substring(1);
+		return classByName(className);
+	}
 
-  private void throwCannotResolveClassNameException(String className) {
-    throw new IllegalArgumentException(String.format("Cannot resolve class name '%s'", className));
-  }
+	private Class<?> classByName(String className) {
+		return ReflectionUtils.loadClass(className).orElse(null);
+	}
 
-  private void throwCannotResolveUniqueIdException(String fullUniqueId, String uniqueIdPart) {
-    throw new IllegalArgumentException(
-        String.format("Cannot resolve part '%s' of unique id '%s'", uniqueIdPart, fullUniqueId));
-  }
+	private void throwCannotResolveClassNameException(String className) {
+		throw new IllegalArgumentException(String.format("Cannot resolve class name '%s'", className));
+	}
 
-  public JUnit5Testable fromClassName(String className) {
-    Preconditions.notEmpty(className, "className must not be empty");
-    Class<?> clazz = classByName(className);
-    if (clazz == null) {
-      throwCannotResolveClassNameException(className);
-    }
-    return fromClass(clazz);
-  }
+	private void throwCannotResolveUniqueIdException(String fullUniqueId, String uniqueIdPart) {
+		throw new IllegalArgumentException(
+			String.format("Cannot resolve part '%s' of unique id '%s'", uniqueIdPart, fullUniqueId));
+	}
 
-  public JUnit5Testable fromClass(Class<?> clazz) {
-    Preconditions.notNull(clazz, "clazz must not be null");
-    String uniqueId = testEngine.getId() + ":" + clazz.getName();
-    return new JUnit5Class(uniqueId, clazz);
-  }
+	public JUnit5Testable fromClassName(String className) {
+		Preconditions.notEmpty(className, "className must not be empty");
+		Class<?> clazz = classByName(className);
+		if (clazz == null) {
+			throwCannotResolveClassNameException(className);
+		}
+		return fromClass(clazz);
+	}
 
-  public JUnit5Testable fromMethod(Method testMethod, Class<?> clazz) {
-    String uniqueId = fromClass(clazz).getUniqueId() + "#" + testMethod.getName()
-        + getParameterIdPart(testMethod);
-    return new JUnit5Method(uniqueId, testMethod, clazz);
-  }
+	public JUnit5Testable fromClass(Class<?> clazz) {
+		Preconditions.notNull(clazz, "clazz must not be null");
+		String uniqueId = testEngine.getId() + ":" + clazz.getName();
+		return new JUnit5Class(uniqueId, clazz);
+	}
 
-  private String getParameterIdPart(Method testMethod) {
-    String parameterString = Arrays.stream(testMethod.getParameterTypes()).map(Class::getName).collect(
-        Collectors.joining(","));
-    return "(" + parameterString + ")";
-  }
+	public JUnit5Testable fromMethod(Method testMethod, Class<?> clazz) {
+		String uniqueId = fromClass(clazz).getUniqueId() + "#" + testMethod.getName() + getParameterIdPart(testMethod);
+		return new JUnit5Method(uniqueId, testMethod, clazz);
+	}
+
+	private String getParameterIdPart(Method testMethod) {
+		String parameterString = Arrays.stream(testMethod.getParameterTypes()).map(Class::getName).collect(
+			Collectors.joining(","));
+		return "(" + parameterString + ")";
+	}
 }

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestableFactory.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestableFactory.java
@@ -1,16 +1,8 @@
-/*
- * Copyright 2015 the original author or authors.
- *
- * All rights reserved. This program and the accompanying materials are
- * made available under the terms of the Eclipse Public License v1.0 which
- * accompanies this distribution and is available at
- *
- * http://www.eclipse.org/legal/epl-v10.html
- */
-
 package org.junit.gen5.engine.junit5.descriptor;
 
-import static org.junit.gen5.commons.util.ReflectionUtils.loadClass;
+import org.junit.gen5.commons.util.Preconditions;
+import org.junit.gen5.commons.util.ReflectionUtils;
+import org.junit.gen5.engine.junit5.JUnit5TestEngine;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
@@ -20,152 +12,151 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.junit.gen5.commons.util.Preconditions;
-import org.junit.gen5.commons.util.ReflectionUtils;
-
 public class JUnit5TestableFactory {
+  private static final String SEPARATORS = ":$#";
+  private final JUnit5TestEngine testEngine;
 
-	private static final String SEPARATORS = ":$#";
+  public JUnit5TestableFactory(JUnit5TestEngine testEngine) {
+    this.testEngine = testEngine;
+  }
 
-	public JUnit5Testable fromUniqueId(String uniqueId, String engineId) {
-		Preconditions.notEmpty(uniqueId, "uniqueId must not be empty");
-		List<String> parts = split(uniqueId);
-		Preconditions.condition(parts.remove(0).equals(engineId), "uniqueId must start with engineId");
+  public JUnit5Testable fromUniqueId(String uniqueId) {
+    Preconditions.notEmpty(uniqueId, "uniqueId must not be empty");
+    List<String> parts = split(uniqueId);
+    Preconditions.condition(parts.remove(0).equals(testEngine.getId()), "uniqueId must start with engineId");
+    return createElement(uniqueId, parts);
+  }
 
-		return createElement(uniqueId, parts);
-	}
+  private List<String> split(String uniqueId) {
+    List<String> parts = new ArrayList<String>();
+    String currentPart = "";
+    for (char c : uniqueId.toCharArray()) {
+      if (SEPARATORS.contains(Character.toString(c))) {
+        parts.add(currentPart);
+        currentPart = "";
+      }
+      currentPart += c;
+    }
+    parts.add(currentPart);
+    return parts;
+  }
 
-	public JUnit5Testable fromClassName(String className, String engineId) {
-		Preconditions.notEmpty(className, "className must not be empty");
-		Class<?> clazz = classByName(className);
-		if (clazz == null) {
-			throwCannotResolveClassNameException(className);
-		}
-		return fromClass(clazz, engineId);
-	}
+  private JUnit5Testable createElement(String uniqueId, List<String> parts) {
+    AnnotatedElement currentJavaElement = null;
+    Class<?> currentJavaContainer = null;
+    String head = parts.remove(0);
+    while (true) {
+      switch (head.charAt(0)) {
+        case ':':
+          currentJavaElement = findTopLevelClass(head);
+          break;
+        case '$':
+          currentJavaContainer = (Class<?>) currentJavaElement;
+          currentJavaElement = findNestedClass(head, (Class<?>) currentJavaElement);
+          break;
+        case '#':
+          currentJavaContainer = (Class<?>) currentJavaElement;
+          currentJavaElement = findMethod(head, currentJavaContainer, uniqueId);
+          break;
+        default:
+          currentJavaContainer = null;
+          currentJavaElement = null;
+      }
 
-	public JUnit5Testable fromClass(Class<?> clazz, String engineId) {
-		Preconditions.notNull(clazz, "clazz must not be null");
-		String uniqueId = engineId + ":" + clazz.getName();
-		return new JUnit5Class(uniqueId, clazz);
-	}
+      if (currentJavaElement == null) {
+        throwCannotResolveUniqueIdException(uniqueId, head);
+      }
+      if (parts.isEmpty())
+        break;
+      head = parts.remove(0);
+    }
+    if (currentJavaElement instanceof Method) {
+      return new JUnit5Method(uniqueId, (Method) currentJavaElement, currentJavaContainer);
+    }
+    if (currentJavaElement instanceof Class) {
+      return new JUnit5Class(uniqueId, (Class<?>) currentJavaElement);
+    }
+    return null; //cannot happen
+  }
 
-	public JUnit5Testable fromMethod(Method testMethod, Class<?> clazz, String engineId) {
-		String uniqueId = fromClass(clazz, engineId).getUniqueId() + "#" + testMethod.getName()
-				+ getParameterIdPart(testMethod);
-		return new JUnit5Method(uniqueId, testMethod, clazz);
-	}
+  private Method findMethod(String methodSpecPart, Class<?> clazz, String uniqueId) {
+    int startParams = methodSpecPart.indexOf('(');
+    String methodName = methodSpecPart.substring(1, startParams);
+    int endParams = methodSpecPart.lastIndexOf(')');
+    String paramsPart = methodSpecPart.substring(startParams + 1, endParams);
+    Class<?>[] parameterTypes = findParameterTypes(paramsPart, uniqueId);
+    return findMethod(clazz, methodName, parameterTypes);
+  }
 
-	private List<String> split(String uniqueId) {
-		List<String> parts = new ArrayList<>();
-		String currentPart = "";
-		for (char c : uniqueId.toCharArray()) {
-			if (SEPARATORS.contains(Character.toString(c))) {
-				parts.add(currentPart);
-				currentPart = "";
-			}
-			currentPart += c;
-		}
-		parts.add(currentPart);
-		return parts;
-	}
+  private Class<?>[] findParameterTypes(String paramsPart, String uniqueId) {
+    if (paramsPart.isEmpty()) {
+      return new Class<?>[0];
+    }
+    List<Class<?>> types = Arrays.stream(paramsPart.split(",")).map(typeName -> {
+      Optional<Class<?>> aClass = ReflectionUtils.loadClass(typeName);
+      if (aClass.isPresent())
+        return aClass.get();
+      else {
+        throwCannotResolveUniqueIdException(uniqueId, paramsPart);
+        return null; //cannot happen
+      }
+    }).collect(Collectors.toList());
+    return types.toArray(new Class<?>[types.size()]);
+  }
 
-	private String getParameterIdPart(Method testMethod) {
-		String parameterString = Arrays.stream(testMethod.getParameterTypes()).map(Class::getName).collect(
-			Collectors.joining(","));
-		return "(" + parameterString + ")";
-	}
+  private Method findMethod(Class<?> clazz, String methodName, Class<?>[] parameterTypes) {
+    return ReflectionUtils.findMethod(clazz, methodName, parameterTypes).orElseThrow(
+        () -> new IllegalArgumentException(String.format("No method with 'name' %s and paramter types '%s'",
+            methodName, Arrays.toString(parameterTypes))));
+  }
 
-	private JUnit5Testable createElement(String uniqueId, List<String> parts) {
-		AnnotatedElement currentJavaElement = null;
-		Class<?> currentJavaContainer = null;
-		String head = parts.remove(0);
-		while (true) {
-			switch (head.charAt(0)) {
-				case ':':
-					currentJavaElement = findTopLevelClass(head);
-					break;
-				case '$':
-					currentJavaContainer = (Class<?>) currentJavaElement;
-					currentJavaElement = findNestedClass(head, (Class<?>) currentJavaElement);
-					break;
-				case '#':
-					currentJavaContainer = (Class<?>) currentJavaElement;
-					currentJavaElement = findMethod(head, currentJavaContainer, uniqueId);
-					break;
-				default:
-					currentJavaContainer = null;
-					currentJavaElement = null;
-			}
+  private Class<?> findNestedClass(String nameExtension, Class<?> containerClass) {
+    String fullClassName = containerClass.getName() + nameExtension;
+    return classByName(fullClassName);
+  }
 
-			if (currentJavaElement == null) {
-				throwCannotResolveUniqueIdException(uniqueId, head);
-			}
-			if (parts.isEmpty())
-				break;
-			head = parts.remove(0);
-		}
-		if (currentJavaElement instanceof Method) {
-			return new JUnit5Method(uniqueId, (Method) currentJavaElement, currentJavaContainer);
-		}
-		if (currentJavaElement instanceof Class) {
-			return new JUnit5Class(uniqueId, (Class<?>) currentJavaElement);
-		}
-		return null; //cannot happen
-	}
+  private Class<?> findTopLevelClass(String classNamePart) {
+    String className = classNamePart.substring(1);
+    return classByName(className);
+  }
 
-	private Method findMethod(String methodSpecPart, Class<?> clazz, String uniqueId) {
-		int startParams = methodSpecPart.indexOf('(');
-		String methodName = methodSpecPart.substring(1, startParams);
-		int endParams = methodSpecPart.lastIndexOf(')');
-		String paramsPart = methodSpecPart.substring(startParams + 1, endParams);
-		Class<?>[] parameterTypes = findParameterTypes(paramsPart, uniqueId);
-		return findMethod(clazz, methodName, parameterTypes);
-	}
+  private Class<?> classByName(String className) {
+    return ReflectionUtils.loadClass(className).orElse(null);
+  }
 
-	private Class<?>[] findParameterTypes(String paramsPart, String uniqueId) {
-		if (paramsPart.isEmpty()) {
-			return new Class<?>[0];
-		}
-		List<Class<?>> types = Arrays.stream(paramsPart.split(",")).map(typeName -> {
-			Optional<Class<?>> aClass = ReflectionUtils.loadClass(typeName);
-			if (aClass.isPresent())
-				return aClass.get();
-			else {
-				throwCannotResolveUniqueIdException(uniqueId, paramsPart);
-				return null; //cannot happen
-			}
-		}).collect(Collectors.toList());
-		return types.toArray(new Class<?>[types.size()]);
-	}
+  private void throwCannotResolveClassNameException(String className) {
+    throw new IllegalArgumentException(String.format("Cannot resolve class name '%s'", className));
+  }
 
-	private Method findMethod(Class<?> clazz, String methodName, Class<?>[] parameterTypes) {
-		return ReflectionUtils.findMethod(clazz, methodName, parameterTypes).orElseThrow(
-			() -> new IllegalArgumentException(String.format("No method with 'name' %s and paramter types '%s'",
-				methodName, Arrays.toString(parameterTypes))));
-	}
+  private void throwCannotResolveUniqueIdException(String fullUniqueId, String uniqueIdPart) {
+    throw new IllegalArgumentException(
+        String.format("Cannot resolve part '%s' of unique id '%s'", uniqueIdPart, fullUniqueId));
+  }
 
-	private Class<?> findNestedClass(String nameExtension, Class<?> containerClass) {
-		String fullClassName = containerClass.getName() + nameExtension;
-		return classByName(fullClassName);
-	}
+  public JUnit5Testable fromClassName(String className) {
+    Preconditions.notEmpty(className, "className must not be empty");
+    Class<?> clazz = classByName(className);
+    if (clazz == null) {
+      throwCannotResolveClassNameException(className);
+    }
+    return fromClass(clazz);
+  }
 
-	private Class<?> findTopLevelClass(String classNamePart) {
-		String className = classNamePart.substring(1);
-		return classByName(className);
-	}
+  public JUnit5Testable fromClass(Class<?> clazz) {
+    Preconditions.notNull(clazz, "clazz must not be null");
+    String uniqueId = testEngine.getId() + ":" + clazz.getName();
+    return new JUnit5Class(uniqueId, clazz);
+  }
 
-	private Class<?> classByName(String className) {
-		return loadClass(className).orElse(null);
-	}
+  public JUnit5Testable fromMethod(Method testMethod, Class<?> clazz) {
+    String uniqueId = fromClass(clazz).getUniqueId() + "#" + testMethod.getName()
+        + getParameterIdPart(testMethod);
+    return new JUnit5Method(uniqueId, testMethod, clazz);
+  }
 
-	private void throwCannotResolveClassNameException(String className) {
-		throw new IllegalArgumentException(String.format("Cannot resolve class name '%s'", className));
-	}
-
-	private void throwCannotResolveUniqueIdException(String fullUniqueId, String uniqueIdPart) {
-		throw new IllegalArgumentException(
-			String.format("Cannot resolve part '%s' of unique id '%s'", uniqueIdPart, fullUniqueId));
-	}
-
+  private String getParameterIdPart(Method testMethod) {
+    String parameterString = Arrays.stream(testMethod.getParameterTypes()).map(Class::getName).collect(
+        Collectors.joining(","));
+    return "(" + parameterString + ")";
+  }
 }

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolver.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolver.java
@@ -44,6 +44,7 @@ public class SpecificationResolver {
 
 	public void resolveElement(TestPlanSpecificationElement element) {
 		element.accept(new TestPlanSpecificationElement.Visitor() {
+
 			@Override
 			public void visitClassNameSpecification(String className) {
 				resolveClassName(className);
@@ -79,6 +80,7 @@ public class SpecificationResolver {
 
 	private void resolveTestable(JUnit5Testable testable) {
 		testable.accept(new JUnit5Testable.Visitor() {
+
 			@Override
 			public void visitClass(String uniqueId, Class<?> testClass) {
 				resolveClass(testClass, uniqueId, parent, true);
@@ -116,8 +118,7 @@ public class SpecificationResolver {
 				ReflectionUtils.MethodSortOrder.HierarchyDown);
 
 			for (Method method : testMethodCandidates) {
-				JUnit5Testable methodTestable = testEngine.fromMethod(method, clazz
-				);
+				JUnit5Testable methodTestable = testEngine.fromMethod(method, clazz);
 				MethodTestDescriptor methodDescriptor = getOrCreateMethodDescriptor(method,
 					methodTestable.getUniqueId());
 				descriptor.addChild(methodDescriptor);

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolver.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolver.java
@@ -44,7 +44,6 @@ public class SpecificationResolver {
 
 	public void resolveElement(TestPlanSpecificationElement element) {
 		element.accept(new TestPlanSpecificationElement.Visitor() {
-
 			@Override
 			public void visitClassNameSpecification(String className) {
 				resolveClassName(className);
@@ -74,14 +73,12 @@ public class SpecificationResolver {
 	}
 
 	private void resolveUniqueId(String uniqueId) {
-
 		JUnit5Testable testable = testEngine.fromUniqueId(uniqueId);
 		resolveTestable(testable);
 	}
 
 	private void resolveTestable(JUnit5Testable testable) {
 		testable.accept(new JUnit5Testable.Visitor() {
-
 			@Override
 			public void visitClass(String uniqueId, Class<?> testClass) {
 				resolveClass(testClass, uniqueId, parent, true);
@@ -91,7 +88,6 @@ public class SpecificationResolver {
 			public void visitMethod(String uniqueId, Method method, Class<?> container) {
 				resolveMethod(method, container, uniqueId, parent);
 			}
-
 		});
 	}
 

--- a/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/JUnit5TestEngineTests.java
+++ b/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/JUnit5TestEngineTests.java
@@ -122,11 +122,7 @@ public class JUnit5TestEngineTests {
 	}
 
 	private List<TestDescriptor> discoverTests(TestPlanSpecification spec) {
-		// For some reason the JUnit5Engine only works correctly if the engine descriptor
-		// is in the list of descriptors
-		EngineDescriptor engineDescriptor = new EngineDescriptor(engine);
-		List<TestDescriptor> descriptors = engine.discoverTests(spec, engineDescriptor);
-		descriptors.add(engineDescriptor);
+		List<TestDescriptor> descriptors = engine.discoverTests(spec);
 		return descriptors;
 	}
 

--- a/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/JUnit5TestableTest.java
+++ b/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/JUnit5TestableTest.java
@@ -15,29 +15,30 @@ import java.math.BigDecimal;
 
 import org.junit.Assert;
 import org.junit.gen5.api.Test;
-import org.junit.gen5.engine.EngineDescriptor;
 import org.junit.gen5.engine.junit5.descriptor.JUnit5Class;
 import org.junit.gen5.engine.junit5.descriptor.JUnit5Method;
-import org.junit.gen5.engine.junit5.descriptor.JUnit5Testable;
 
 public class JUnit5TestableTest {
-
-	EngineDescriptor engineDescriptor = new EngineDescriptor(new JUnit5TestEngine());
+	private final JUnit5TestEngine testEngine = new JUnit5TestEngine();
 
 	@org.junit.Test
 	public void fromUniqueIdForTopLevelClass() {
 
-		JUnit5Class testable = (JUnit5Class) JUnit5Testable.fromUniqueId(
-			"junit5:org.junit.gen5.engine.junit5.ATestClass", engineDescriptor.getUniqueId());
+		JUnit5Class testable = (JUnit5Class) JUnit5TestEngine.fromUniqueId(
+				"junit5:org.junit.gen5.engine.junit5.ATestClass");
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass", testable.getUniqueId());
 		Assert.assertSame(ATestClass.class, testable.getJavaClass());
+	}
+
+	private String getEngineId() {
+		return testEngine.getId();
 	}
 
 	@org.junit.Test
 	public void fromUniqueIdForNestedClass() {
 
-		JUnit5Class testable = (JUnit5Class) JUnit5Testable.fromUniqueId(
-			"junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass", engineDescriptor.getUniqueId());
+		JUnit5Class testable = (JUnit5Class) JUnit5TestEngine.fromUniqueId(
+				"junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass");
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass", testable.getUniqueId());
 		Assert.assertSame(ATestClass.AnInnerTestClass.class, testable.getJavaClass());
 	}
@@ -45,9 +46,9 @@ public class JUnit5TestableTest {
 	@org.junit.Test
 	public void fromUniqueIdForDoubleNestedClass() {
 
-		JUnit5Class testable = (JUnit5Class) JUnit5Testable.fromUniqueId(
-			"junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass$InnerInnerTestClass",
-			engineDescriptor.getUniqueId());
+		JUnit5Class testable = (JUnit5Class) JUnit5TestEngine.fromUniqueId(
+				"junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass$InnerInnerTestClass"
+		);
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass$InnerInnerTestClass",
 			testable.getUniqueId());
 		Assert.assertSame(ATestClass.AnInnerTestClass.InnerInnerTestClass.class, testable.getJavaClass());
@@ -56,8 +57,8 @@ public class JUnit5TestableTest {
 	@org.junit.Test
 	public void fromUniqueIdForMethod() throws NoSuchMethodException {
 
-		JUnit5Method testable = (JUnit5Method) JUnit5Testable.fromUniqueId(
-			"junit5:org.junit.gen5.engine.junit5.ATestClass#test1()", engineDescriptor.getUniqueId());
+		JUnit5Method testable = (JUnit5Method) JUnit5TestEngine.fromUniqueId(
+				"junit5:org.junit.gen5.engine.junit5.ATestClass#test1()");
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass#test1()", testable.getUniqueId());
 		Method testMethod = ATestClass.class.getDeclaredMethod("test1", new Class[0]);
 		Assert.assertEquals(testMethod, testable.getJavaMethod());
@@ -66,9 +67,9 @@ public class JUnit5TestableTest {
 	@org.junit.Test
 	public void fromUniqueIdForMethodWithParameters() throws NoSuchMethodException {
 
-		JUnit5Method testable = (JUnit5Method) JUnit5Testable.fromUniqueId(
-			"junit5:org.junit.gen5.engine.junit5.BTestClass#test4(java.lang.String,java.math.BigDecimal)",
-			engineDescriptor.getUniqueId());
+		JUnit5Method testable = (JUnit5Method) JUnit5TestEngine.fromUniqueId(
+				"junit5:org.junit.gen5.engine.junit5.BTestClass#test4(java.lang.String,java.math.BigDecimal)"
+		);
 		Assert.assertEquals(
 			"junit5:org.junit.gen5.engine.junit5.BTestClass#test4(java.lang.String,java.math.BigDecimal)",
 			testable.getUniqueId());
@@ -79,8 +80,8 @@ public class JUnit5TestableTest {
 	@org.junit.Test
 	public void fromUniqueIdForMethodInNestedClass() throws NoSuchMethodException {
 
-		JUnit5Method testable = (JUnit5Method) JUnit5Testable.fromUniqueId(
-			"junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass#test2()", engineDescriptor.getUniqueId());
+		JUnit5Method testable = (JUnit5Method) JUnit5TestEngine.fromUniqueId(
+				"junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass#test2()");
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass#test2()",
 			testable.getUniqueId());
 		Method testMethod = ATestClass.AnInnerTestClass.class.getDeclaredMethod("test2", new Class[0]);
@@ -89,16 +90,16 @@ public class JUnit5TestableTest {
 
 	@org.junit.Test
 	public void fromClassName() throws NoSuchMethodException {
-		JUnit5Class testable = (JUnit5Class) JUnit5Testable.fromClassName("org.junit.gen5.engine.junit5.ATestClass",
-			engineDescriptor.getUniqueId());
+		JUnit5Class testable = (JUnit5Class) JUnit5TestEngine.fromClassName("org.junit.gen5.engine.junit5.ATestClass"
+		);
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass", testable.getUniqueId());
 		Assert.assertSame(ATestClass.class, testable.getJavaClass());
 	}
 
 	@org.junit.Test
 	public void nestedClassFromClassName() throws NoSuchMethodException {
-		JUnit5Class testable = (JUnit5Class) JUnit5Testable.fromClassName(
-			"org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass", engineDescriptor.getUniqueId());
+		JUnit5Class testable = (JUnit5Class) JUnit5TestEngine.fromClassName(
+				"org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass");
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass", testable.getUniqueId());
 		Assert.assertSame(ATestClass.AnInnerTestClass.class, testable.getJavaClass());
 	}
@@ -106,8 +107,8 @@ public class JUnit5TestableTest {
 	@org.junit.Test
 	public void fromMethod() throws NoSuchMethodException {
 		Method testMethod = ATestClass.class.getDeclaredMethod("test1", new Class[0]);
-		JUnit5Method testable = (JUnit5Method) JUnit5Testable.fromMethod(testMethod, ATestClass.class,
-			engineDescriptor.getUniqueId());
+		JUnit5Method testable = (JUnit5Method) JUnit5TestEngine.fromMethod(testMethod, ATestClass.class
+		);
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass#test1()", testable.getUniqueId());
 		Assert.assertSame(testMethod, testable.getJavaMethod());
 		Assert.assertSame(ATestClass.class, testable.getContainerClass());
@@ -116,8 +117,8 @@ public class JUnit5TestableTest {
 	@org.junit.Test
 	public void fromMethodWithParameters() throws NoSuchMethodException {
 		Method testMethod = BTestClass.class.getDeclaredMethod("test4", String.class, BigDecimal.class);
-		JUnit5Method testable = (JUnit5Method) JUnit5Testable.fromMethod(testMethod, BTestClass.class,
-			engineDescriptor.getUniqueId());
+		JUnit5Method testable = (JUnit5Method) JUnit5TestEngine.fromMethod(testMethod, BTestClass.class
+		);
 		Assert.assertEquals(
 			"junit5:org.junit.gen5.engine.junit5.BTestClass#test4(java.lang.String,java.math.BigDecimal)",
 			testable.getUniqueId());

--- a/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/JUnit5TestableTest.java
+++ b/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/JUnit5TestableTest.java
@@ -19,12 +19,12 @@ import org.junit.gen5.engine.junit5.descriptor.JUnit5Class;
 import org.junit.gen5.engine.junit5.descriptor.JUnit5Method;
 
 public class JUnit5TestableTest {
+
 	private final JUnit5TestEngine testEngine = new JUnit5TestEngine();
 
 	@org.junit.Test
 	public void fromUniqueIdForTopLevelClass() {
-		JUnit5Class testable = (JUnit5Class) testEngine.fromUniqueId(
-				"junit5:org.junit.gen5.engine.junit5.ATestClass");
+		JUnit5Class testable = (JUnit5Class) testEngine.fromUniqueId("junit5:org.junit.gen5.engine.junit5.ATestClass");
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass", testable.getUniqueId());
 		Assert.assertSame(ATestClass.class, testable.getJavaClass());
 	}
@@ -33,7 +33,7 @@ public class JUnit5TestableTest {
 	public void fromUniqueIdForNestedClass() {
 
 		JUnit5Class testable = (JUnit5Class) testEngine.fromUniqueId(
-				"junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass");
+			"junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass");
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass", testable.getUniqueId());
 		Assert.assertSame(ATestClass.AnInnerTestClass.class, testable.getJavaClass());
 	}
@@ -42,8 +42,7 @@ public class JUnit5TestableTest {
 	public void fromUniqueIdForDoubleNestedClass() {
 
 		JUnit5Class testable = (JUnit5Class) testEngine.fromUniqueId(
-				"junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass$InnerInnerTestClass"
-		);
+			"junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass$InnerInnerTestClass");
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass$InnerInnerTestClass",
 			testable.getUniqueId());
 		Assert.assertSame(ATestClass.AnInnerTestClass.InnerInnerTestClass.class, testable.getJavaClass());
@@ -53,7 +52,7 @@ public class JUnit5TestableTest {
 	public void fromUniqueIdForMethod() throws NoSuchMethodException {
 
 		JUnit5Method testable = (JUnit5Method) testEngine.fromUniqueId(
-				"junit5:org.junit.gen5.engine.junit5.ATestClass#test1()");
+			"junit5:org.junit.gen5.engine.junit5.ATestClass#test1()");
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass#test1()", testable.getUniqueId());
 		Method testMethod = ATestClass.class.getDeclaredMethod("test1", new Class[0]);
 		Assert.assertEquals(testMethod, testable.getJavaMethod());
@@ -63,8 +62,7 @@ public class JUnit5TestableTest {
 	public void fromUniqueIdForMethodWithParameters() throws NoSuchMethodException {
 
 		JUnit5Method testable = (JUnit5Method) testEngine.fromUniqueId(
-				"junit5:org.junit.gen5.engine.junit5.BTestClass#test4(java.lang.String,java.math.BigDecimal)"
-		);
+			"junit5:org.junit.gen5.engine.junit5.BTestClass#test4(java.lang.String,java.math.BigDecimal)");
 		Assert.assertEquals(
 			"junit5:org.junit.gen5.engine.junit5.BTestClass#test4(java.lang.String,java.math.BigDecimal)",
 			testable.getUniqueId());
@@ -76,7 +74,7 @@ public class JUnit5TestableTest {
 	public void fromUniqueIdForMethodInNestedClass() throws NoSuchMethodException {
 
 		JUnit5Method testable = (JUnit5Method) testEngine.fromUniqueId(
-				"junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass#test2()");
+			"junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass#test2()");
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass#test2()",
 			testable.getUniqueId());
 		Method testMethod = ATestClass.AnInnerTestClass.class.getDeclaredMethod("test2", new Class[0]);
@@ -85,8 +83,7 @@ public class JUnit5TestableTest {
 
 	@org.junit.Test
 	public void fromClassName() throws NoSuchMethodException {
-		JUnit5Class testable = (JUnit5Class) testEngine.fromClassName("org.junit.gen5.engine.junit5.ATestClass"
-		);
+		JUnit5Class testable = (JUnit5Class) testEngine.fromClassName("org.junit.gen5.engine.junit5.ATestClass");
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass", testable.getUniqueId());
 		Assert.assertSame(ATestClass.class, testable.getJavaClass());
 	}
@@ -94,7 +91,7 @@ public class JUnit5TestableTest {
 	@org.junit.Test
 	public void nestedClassFromClassName() throws NoSuchMethodException {
 		JUnit5Class testable = (JUnit5Class) testEngine.fromClassName(
-				"org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass");
+			"org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass");
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass", testable.getUniqueId());
 		Assert.assertSame(ATestClass.AnInnerTestClass.class, testable.getJavaClass());
 	}
@@ -102,8 +99,7 @@ public class JUnit5TestableTest {
 	@org.junit.Test
 	public void fromMethod() throws NoSuchMethodException {
 		Method testMethod = ATestClass.class.getDeclaredMethod("test1", new Class[0]);
-		JUnit5Method testable = (JUnit5Method) testEngine.fromMethod(testMethod, ATestClass.class
-		);
+		JUnit5Method testable = (JUnit5Method) testEngine.fromMethod(testMethod, ATestClass.class);
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass#test1()", testable.getUniqueId());
 		Assert.assertSame(testMethod, testable.getJavaMethod());
 		Assert.assertSame(ATestClass.class, testable.getContainerClass());
@@ -112,8 +108,7 @@ public class JUnit5TestableTest {
 	@org.junit.Test
 	public void fromMethodWithParameters() throws NoSuchMethodException {
 		Method testMethod = BTestClass.class.getDeclaredMethod("test4", String.class, BigDecimal.class);
-		JUnit5Method testable = (JUnit5Method) testEngine.fromMethod(testMethod, BTestClass.class
-		);
+		JUnit5Method testable = (JUnit5Method) testEngine.fromMethod(testMethod, BTestClass.class);
 		Assert.assertEquals(
 			"junit5:org.junit.gen5.engine.junit5.BTestClass#test4(java.lang.String,java.math.BigDecimal)",
 			testable.getUniqueId());

--- a/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/JUnit5TestableTest.java
+++ b/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/JUnit5TestableTest.java
@@ -24,20 +24,16 @@ public class JUnit5TestableTest {
 	@org.junit.Test
 	public void fromUniqueIdForTopLevelClass() {
 
-		JUnit5Class testable = (JUnit5Class) JUnit5TestEngine.fromUniqueId(
+		JUnit5Class testable = (JUnit5Class) testEngine.fromUniqueId(
 				"junit5:org.junit.gen5.engine.junit5.ATestClass");
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass", testable.getUniqueId());
 		Assert.assertSame(ATestClass.class, testable.getJavaClass());
 	}
 
-	private String getEngineId() {
-		return testEngine.getId();
-	}
-
 	@org.junit.Test
 	public void fromUniqueIdForNestedClass() {
 
-		JUnit5Class testable = (JUnit5Class) JUnit5TestEngine.fromUniqueId(
+		JUnit5Class testable = (JUnit5Class) testEngine.fromUniqueId(
 				"junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass");
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass", testable.getUniqueId());
 		Assert.assertSame(ATestClass.AnInnerTestClass.class, testable.getJavaClass());
@@ -46,7 +42,7 @@ public class JUnit5TestableTest {
 	@org.junit.Test
 	public void fromUniqueIdForDoubleNestedClass() {
 
-		JUnit5Class testable = (JUnit5Class) JUnit5TestEngine.fromUniqueId(
+		JUnit5Class testable = (JUnit5Class) testEngine.fromUniqueId(
 				"junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass$InnerInnerTestClass"
 		);
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass$InnerInnerTestClass",
@@ -57,7 +53,7 @@ public class JUnit5TestableTest {
 	@org.junit.Test
 	public void fromUniqueIdForMethod() throws NoSuchMethodException {
 
-		JUnit5Method testable = (JUnit5Method) JUnit5TestEngine.fromUniqueId(
+		JUnit5Method testable = (JUnit5Method) testEngine.fromUniqueId(
 				"junit5:org.junit.gen5.engine.junit5.ATestClass#test1()");
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass#test1()", testable.getUniqueId());
 		Method testMethod = ATestClass.class.getDeclaredMethod("test1", new Class[0]);
@@ -67,7 +63,7 @@ public class JUnit5TestableTest {
 	@org.junit.Test
 	public void fromUniqueIdForMethodWithParameters() throws NoSuchMethodException {
 
-		JUnit5Method testable = (JUnit5Method) JUnit5TestEngine.fromUniqueId(
+		JUnit5Method testable = (JUnit5Method) testEngine.fromUniqueId(
 				"junit5:org.junit.gen5.engine.junit5.BTestClass#test4(java.lang.String,java.math.BigDecimal)"
 		);
 		Assert.assertEquals(
@@ -80,7 +76,7 @@ public class JUnit5TestableTest {
 	@org.junit.Test
 	public void fromUniqueIdForMethodInNestedClass() throws NoSuchMethodException {
 
-		JUnit5Method testable = (JUnit5Method) JUnit5TestEngine.fromUniqueId(
+		JUnit5Method testable = (JUnit5Method) testEngine.fromUniqueId(
 				"junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass#test2()");
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass#test2()",
 			testable.getUniqueId());
@@ -90,7 +86,7 @@ public class JUnit5TestableTest {
 
 	@org.junit.Test
 	public void fromClassName() throws NoSuchMethodException {
-		JUnit5Class testable = (JUnit5Class) JUnit5TestEngine.fromClassName("org.junit.gen5.engine.junit5.ATestClass"
+		JUnit5Class testable = (JUnit5Class) testEngine.fromClassName("org.junit.gen5.engine.junit5.ATestClass"
 		);
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass", testable.getUniqueId());
 		Assert.assertSame(ATestClass.class, testable.getJavaClass());
@@ -98,7 +94,7 @@ public class JUnit5TestableTest {
 
 	@org.junit.Test
 	public void nestedClassFromClassName() throws NoSuchMethodException {
-		JUnit5Class testable = (JUnit5Class) JUnit5TestEngine.fromClassName(
+		JUnit5Class testable = (JUnit5Class) testEngine.fromClassName(
 				"org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass");
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass$AnInnerTestClass", testable.getUniqueId());
 		Assert.assertSame(ATestClass.AnInnerTestClass.class, testable.getJavaClass());
@@ -107,7 +103,7 @@ public class JUnit5TestableTest {
 	@org.junit.Test
 	public void fromMethod() throws NoSuchMethodException {
 		Method testMethod = ATestClass.class.getDeclaredMethod("test1", new Class[0]);
-		JUnit5Method testable = (JUnit5Method) JUnit5TestEngine.fromMethod(testMethod, ATestClass.class
+		JUnit5Method testable = (JUnit5Method) testEngine.fromMethod(testMethod, ATestClass.class
 		);
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass#test1()", testable.getUniqueId());
 		Assert.assertSame(testMethod, testable.getJavaMethod());
@@ -117,7 +113,7 @@ public class JUnit5TestableTest {
 	@org.junit.Test
 	public void fromMethodWithParameters() throws NoSuchMethodException {
 		Method testMethod = BTestClass.class.getDeclaredMethod("test4", String.class, BigDecimal.class);
-		JUnit5Method testable = (JUnit5Method) JUnit5TestEngine.fromMethod(testMethod, BTestClass.class
+		JUnit5Method testable = (JUnit5Method) testEngine.fromMethod(testMethod, BTestClass.class
 		);
 		Assert.assertEquals(
 			"junit5:org.junit.gen5.engine.junit5.BTestClass#test4(java.lang.String,java.math.BigDecimal)",

--- a/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/JUnit5TestableTest.java
+++ b/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/JUnit5TestableTest.java
@@ -23,7 +23,6 @@ public class JUnit5TestableTest {
 
 	@org.junit.Test
 	public void fromUniqueIdForTopLevelClass() {
-
 		JUnit5Class testable = (JUnit5Class) testEngine.fromUniqueId(
 				"junit5:org.junit.gen5.engine.junit5.ATestClass");
 		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.ATestClass", testable.getUniqueId());

--- a/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/SpecificationResolverTest.java
+++ b/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/SpecificationResolverTest.java
@@ -26,14 +26,16 @@ import org.junit.gen5.engine.junit5.descriptor.SpecificationResolver;
 public class SpecificationResolverTest {
 
 	private Set<TestDescriptor> descriptors;
+	private JUnit5TestEngine testEngine;
 	private EngineDescriptor engineDescriptor;
 	private SpecificationResolver resolver;
 
 	@org.junit.Before
 	public void init() {
 		descriptors = new HashSet<>();
-		engineDescriptor = new EngineDescriptor(new JUnit5TestEngine());
-		resolver = new SpecificationResolver(descriptors, engineDescriptor);
+		testEngine = new JUnit5TestEngine();
+		engineDescriptor = new EngineDescriptor(testEngine);
+		resolver = new SpecificationResolver(testEngine, descriptors, engineDescriptor);
 	}
 
 	@org.junit.Test

--- a/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/stubs/TestEngineStub.java
+++ b/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/stubs/TestEngineStub.java
@@ -28,8 +28,7 @@ public class TestEngineStub implements TestEngine {
 	}
 
 	@Override
-	public Collection<TestDescriptor> discoverTests(TestPlanSpecification specification,
-			EngineDescriptor engineDescriptor) {
+	public Collection<TestDescriptor> discoverTests(TestPlanSpecification specification) {
 		return null;
 	}
 


### PR DESCRIPTION
I moved the responsibility for taking care about the engineId into the Engine class and its helpers. Any class outside of the junit5-engine package should not operate on the engine id.

With this change I also introduce delegate methods on the engine class which might be a good indicator in which way we should move on:

```
public JUnit5Testable fromUniqueId(String uniqueId) {
		return testableFactory.fromUniqueId(uniqueId);
	}

	public JUnit5Testable fromClassName(String className) {
		return testableFactory.fromClassName(className);
	}

	public JUnit5Testable fromClass(Class<?> clazz) {
		return testableFactory.fromClass(clazz);
	}

	public JUnit5Testable fromMethod(Method testMethod, Class<?> clazz) {
		return testableFactory.fromMethod(testMethod, clazz);
	}
```

We could extract these methods into the test engine interface, i.e. each engine is responsible for the resolution. With that approach we could extract the more generic part of the resolver into a separate class that operates on and interacts with all engines. Still a way to go, but I wanted to point into this direction. What do you think? 