### PR TITLE
Hierarchical Test Descriptor

### DIFF
--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
@@ -26,7 +26,7 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 
 	private TestDescriptor parent;
 
-	private final Set<AbstractTestDescriptor> children = new LinkedHashSet<>();
+	private final Set<TestDescriptor> children = new LinkedHashSet<>();
 
 	protected AbstractTestDescriptor(String uniqueId) {
 		Preconditions.notBlank(uniqueId, "uniqueId must not be null or empty");
@@ -39,7 +39,7 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	}
 
 	@Override
-	public final TestDescriptor getParent() {
+	public TestDescriptor getParent() {
 		return this.parent;
 	}
 
@@ -48,13 +48,14 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 		this.parent = parent;
 	}
 
-	public final void addChild(AbstractTestDescriptor child) {
+	public final void addChild(TestDescriptor child) {
 		Preconditions.notNull(child, "child must not be null");
-		child.setParent(this);
+		if (child instanceof AbstractTestDescriptor)
+			((AbstractTestDescriptor) child).setParent(this);
 		this.children.add(child);
 	}
 
-	public final Set<AbstractTestDescriptor> getChildren() {
+	public final Set<TestDescriptor> getChildren() {
 		return this.children;
 	}
 

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
@@ -10,11 +10,10 @@
 
 package org.junit.gen5.engine;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.gen5.commons.util.Preconditions;
@@ -42,8 +41,8 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	}
 
 	@Override
-	public TestDescriptor getParent() {
-		return this.parent;
+	public Optional<TestDescriptor> getParent() {
+		return Optional.ofNullable(this.parent);
 	}
 
 	public final void setParent(TestDescriptor parent) {

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
@@ -53,7 +53,7 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 
 	protected void removeFromHierarchy() {
 		if (isRoot())
-			return;
+			throw new UnsupportedOperationException("You cannot remove the root of a hierarchy.");
 		if (parent instanceof AbstractTestDescriptor)
 			((AbstractTestDescriptor) parent).removeChild(this);
 		setParent(null);
@@ -75,8 +75,8 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 
 	@Override
 	public void accept(Visitor visitor) {
-		Runnable delete = () -> removeFromHierarchy();
-		visitor.visit(this, delete);
+		Runnable remove = () -> removeFromHierarchy();
+		visitor.visit(this, remove);
 		new LinkedHashSet<>(getChildren()).forEach(child -> child.accept(visitor));
 	}
 

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
@@ -10,9 +10,11 @@
 
 package org.junit.gen5.engine;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.gen5.commons.util.Preconditions;

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
@@ -44,20 +44,21 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 		return this.parent;
 	}
 
-	protected final void setParent(TestDescriptor parent) {
+	public final void setParent(TestDescriptor parent) {
 		this.parent = parent;
 	}
 
-	protected void removeChild(AbstractTestDescriptor abstractTestDescriptor) {
-		children.remove(abstractTestDescriptor);
+	@Override
+	public void removeChild(TestDescriptor child) {
+		children.remove(child);
+		if (child instanceof AbstractTestDescriptor)
+			((AbstractTestDescriptor) child).setParent(null);
 	}
 
 	protected void removeFromHierarchy() {
 		if (isRoot())
 			throw new UnsupportedOperationException("You cannot remove the root of a hierarchy.");
-		if (parent instanceof AbstractTestDescriptor)
-			((AbstractTestDescriptor) parent).removeChild(this);
-		setParent(null);
+		parent.removeChild(this);
 		children.clear();
 	}
 
@@ -87,7 +88,7 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	public void accept(Visitor visitor) {
 		Runnable remove = () -> removeFromHierarchy();
 		visitor.visit(this, remove);
-		new LinkedHashSet<>(getChildren()).forEach(child -> child.accept(visitor));
+		new HashSet<>(getChildren()).forEach(child -> child.accept(visitor));
 	}
 
 	@Override

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
@@ -51,7 +51,6 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 		children.remove(abstractTestDescriptor);
 	}
 
-
 	@Override
 	public void remove() {
 		if (parent instanceof AbstractTestDescriptor)

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
@@ -60,6 +60,12 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	}
 
 	@Override
+	public void accept(Visitor visitor) {
+		visitor.visit(this);
+		getChildren().forEach(child -> visitor.visit(child));
+	}
+
+	@Override
 	public Set<TestTag> getTags() {
 		return Collections.emptySet();
 	}

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
@@ -51,12 +51,13 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 		children.remove(abstractTestDescriptor);
 	}
 
-	@Override
-	public void remove() {
+	protected void removeFromHierarchy() {
+		if (isRoot())
+			return;
 		if (parent instanceof AbstractTestDescriptor)
 			((AbstractTestDescriptor) parent).removeChild(this);
 		setParent(null);
-		children.clear(); //to prevent visiting
+		children.clear();
 	}
 
 	@Override
@@ -74,7 +75,8 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 
 	@Override
 	public void accept(Visitor visitor) {
-		visitor.visit(this);
+		Runnable delete = () -> removeFromHierarchy();
+		visitor.visit(this, delete);
 		new LinkedHashSet<>(getChildren()).forEach(child -> child.accept(visitor));
 	}
 

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
@@ -11,6 +11,7 @@
 package org.junit.gen5.engine;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -58,6 +59,15 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 			((AbstractTestDescriptor) parent).removeChild(this);
 		setParent(null);
 		children.clear();
+	}
+
+	public Set<TestDescriptor> allChildren() {
+		Set<TestDescriptor> all = new HashSet<>();
+		all.addAll(children);
+		for (TestDescriptor child : children) {
+			all.addAll(((AbstractTestDescriptor) child).allChildren());
+		}
+		return all;
 	}
 
 	@Override

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
@@ -44,10 +44,23 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	}
 
 	protected final void setParent(TestDescriptor parent) {
-		Preconditions.notNull(parent, "parent must not be null");
 		this.parent = parent;
 	}
 
+	protected void removeChild(AbstractTestDescriptor abstractTestDescriptor) {
+		children.remove(abstractTestDescriptor);
+	}
+
+
+	@Override
+	public void remove() {
+		if (parent instanceof AbstractTestDescriptor)
+			((AbstractTestDescriptor) parent).removeChild(this);
+		setParent(null);
+		children.clear(); //to prevent visiting
+	}
+
+	@Override
 	public final void addChild(TestDescriptor child) {
 		Preconditions.notNull(child, "child must not be null");
 		if (child instanceof AbstractTestDescriptor)
@@ -55,6 +68,7 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 		this.children.add(child);
 	}
 
+	@Override
 	public final Set<TestDescriptor> getChildren() {
 		return this.children;
 	}
@@ -62,7 +76,7 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	@Override
 	public void accept(Visitor visitor) {
 		visitor.visit(this);
-		getChildren().forEach(child -> visitor.visit(child));
+		new LinkedHashSet<>(getChildren()).forEach(child -> child.accept(visitor));
 	}
 
 	@Override

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
@@ -94,7 +94,7 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 
 	@Override
 	public void accept(Visitor visitor) {
-		Runnable remove = () -> removeFromHierarchy();
+		Runnable remove = this::removeFromHierarchy;
 		visitor.visit(this, remove);
 		new HashSet<>(getChildren()).forEach(child -> child.accept(visitor));
 	}

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/EngineDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/EngineDescriptor.java
@@ -10,6 +10,9 @@
 
 package org.junit.gen5.engine;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class EngineDescriptor extends AbstractTestDescriptor {
 
 	private final TestEngine engine;
@@ -32,4 +35,5 @@ public class EngineDescriptor extends AbstractTestDescriptor {
 	public TestEngine getEngine() {
 		return engine;
 	}
+
 }

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/EngineDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/EngineDescriptor.java
@@ -29,4 +29,7 @@ public class EngineDescriptor extends AbstractTestDescriptor {
 		return false;
 	}
 
+	public TestEngine getEngine() {
+		return engine;
+	}
 }

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/EngineExecutionContext.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/EngineExecutionContext.java
@@ -10,7 +10,6 @@
 
 package org.junit.gen5.engine;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -19,7 +18,7 @@ import lombok.Value;
 @Value
 public class EngineExecutionContext {
 
-	private Collection<TestDescriptor> testDescriptors;
+	private EngineDescriptor engineDescriptor;
 
 	private TestExecutionListener testExecutionListener;
 

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
@@ -44,7 +44,7 @@ public interface TestDescriptor {
 
 	interface Visitor {
 
-		void visit(TestDescriptor descriptor, Runnable deleteCurrent);
+		void visit(TestDescriptor descriptor, Runnable remove);
 	}
 
 	void accept(Visitor visitor);

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
@@ -19,8 +19,6 @@ import java.util.Set;
  */
 public interface TestDescriptor {
 
-	// Todo: Move modifying methods and visitor to sub type ModifiableTestDescriptor?
-
 	/**
 	 * Get the unique identifier (UID) for the described test.
 	 *

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
@@ -40,7 +40,15 @@ public interface TestDescriptor {
 
 	void addChild(TestDescriptor descriptor);
 
+	void removeChild(TestDescriptor descriptor);
+
 	Set<TestDescriptor> getChildren();
+
+	default boolean hasTests() {
+		if (isTest())
+			return true;
+		return getChildren().stream().anyMatch(anyDescriptor -> anyDescriptor.hasTests());
+	}
 
 	interface Visitor {
 

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
@@ -10,6 +10,7 @@
 
 package org.junit.gen5.engine;
 
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -18,7 +19,7 @@ import java.util.Set;
  */
 public interface TestDescriptor {
 
-	// Todo: Move modifying methods and visitor to sub type ModifiableTestDescriptor
+	// Todo: Move modifying methods and visitor to sub type ModifiableTestDescriptor?
 
 	/**
 	 * Get the unique identifier (UID) for the described test.
@@ -50,6 +51,13 @@ public interface TestDescriptor {
 		if (isTest())
 			return true;
 		return getChildren().stream().anyMatch(anyDescriptor -> anyDescriptor.hasTests());
+	}
+
+	default Optional<TestDescriptor> findByUniqueId(String uniqueId) {
+		if (getUniqueId().equals(uniqueId))
+			return Optional.of(this);
+		return getChildren().stream().filter(
+			testDescriptor -> testDescriptor.getUniqueId().equals(uniqueId)).findFirst();
 	}
 
 	interface Visitor {

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
@@ -41,6 +41,7 @@ public interface TestDescriptor {
 	Set<TestDescriptor> getChildren();
 
 	interface Visitor {
+
 		void visit(TestDescriptor descriptor);
 	}
 

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
@@ -32,17 +32,19 @@ public interface TestDescriptor {
 
 	boolean isTest();
 
+	default boolean isRoot() {
+		return getParent() == null;
+	}
+
 	Set<TestTag> getTags();
 
 	void addChild(TestDescriptor descriptor);
-
-	void remove();
 
 	Set<TestDescriptor> getChildren();
 
 	interface Visitor {
 
-		void visit(TestDescriptor descriptor);
+		void visit(TestDescriptor descriptor, Runnable deleteCurrent);
 	}
 
 	void accept(Visitor visitor);

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
@@ -36,6 +36,8 @@ public interface TestDescriptor {
 
 	void addChild(TestDescriptor descriptor);
 
+	void remove();
+
 	Set<TestDescriptor> getChildren();
 
 	interface Visitor {

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
@@ -37,4 +37,10 @@ public interface TestDescriptor {
 	void addChild(TestDescriptor descriptor);
 
 	Set<TestDescriptor> getChildren();
+
+	interface Visitor {
+		void visit(TestDescriptor descriptor);
+	}
+
+	void accept(Visitor visitor);
 }

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
@@ -31,7 +31,7 @@ public interface TestDescriptor {
 
 	String getDisplayName();
 
-	TestDescriptor getParent();
+	Optional<TestDescriptor> getParent();
 
 	boolean isTest();
 

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
@@ -33,4 +33,8 @@ public interface TestDescriptor {
 	boolean isTest();
 
 	Set<TestTag> getTags();
+
+	void addChild(TestDescriptor descriptor);
+
+	Set<TestDescriptor> getChildren();
 }

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
@@ -18,6 +18,8 @@ import java.util.Set;
  */
 public interface TestDescriptor {
 
+	// Todo: Move modifying methods and visitor to sub type ModifiableTestDescriptor
+
 	/**
 	 * Get the unique identifier (UID) for the described test.
 	 *

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/TestEngine.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/TestEngine.java
@@ -10,15 +10,13 @@
 
 package org.junit.gen5.engine;
 
-import java.util.Collection;
-
 public interface TestEngine {
 
 	default String getId() {
 		return getClass().getCanonicalName();
 	}
 
-	Collection<TestDescriptor> discoverTests(TestPlanSpecification specification, EngineDescriptor engineDescriptor);
+	void discoverTests(TestPlanSpecification specification, EngineDescriptor engineDescriptor);
 
 	default boolean supports(TestDescriptor testDescriptor) {
 		return testDescriptor.getUniqueId().startsWith(getId());

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/TestEngine.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/TestEngine.java
@@ -18,9 +18,5 @@ public interface TestEngine {
 
 	void discoverTests(TestPlanSpecification specification, EngineDescriptor engineDescriptor);
 
-	default boolean supports(TestDescriptor testDescriptor) {
-		return testDescriptor.getUniqueId().startsWith(getId());
-	}
-
 	void execute(EngineExecutionContext context);
 }

--- a/junit-engine-api/src/test/java/org/junit/gen5/engine/AbstractTestDescriptorTest.java
+++ b/junit-engine-api/src/test/java/org/junit/gen5/engine/AbstractTestDescriptorTest.java
@@ -1,0 +1,96 @@
+package org.junit.gen5.engine;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AbstractTestDescriptorTest {
+
+	EngineDescriptor engineDescriptor;
+
+	@Before
+	public void initTree() {
+		engineDescriptor = new EngineDescriptor(new TestEngine() {
+			@Override
+			public Collection<TestDescriptor> discoverTests(TestPlanSpecification specification,
+				EngineDescriptor engineDescriptor) {
+				return null;
+			}
+			@Override
+			public void execute(EngineExecutionContext context) {
+
+			}
+
+			@Override
+			public String getId() {
+				return "testEngine";
+			}
+		});
+		GroupDescriptor group1 = new GroupDescriptor("group1");
+		engineDescriptor.addChild(group1);
+		GroupDescriptor group2 = new GroupDescriptor("group2");
+		engineDescriptor.addChild(group2);
+		GroupDescriptor group11 = new GroupDescriptor("group1-1");
+		group1.addChild(group11);
+
+		group1.addChild(new LeafDescriptor("leaf1-1"));
+		group1.addChild(new LeafDescriptor("leaf1-2"));
+
+		group2.addChild(new LeafDescriptor("leaf2-1"));
+
+		group11.addChild(new LeafDescriptor("leaf11-1"));
+	}
+
+	@Test
+	public void visitAllNodes() {
+		List<TestDescriptor> visited = new ArrayList<>();
+
+		TestDescriptor.Visitor visitor = new TestDescriptor.Visitor() {
+
+			@Override
+			public void visit(TestDescriptor descriptor) {
+				visited.add(descriptor);
+			}
+		};
+		engineDescriptor.accept(visitor);
+
+		Assert.assertEquals(9, visited.size());
+	}
+}
+
+class GroupDescriptor extends AbstractTestDescriptor {
+
+	GroupDescriptor(String uniqueId) {
+		super(uniqueId);
+	}
+
+	@Override
+	public String getDisplayName() {
+		return "group: " + getUniqueId();
+	}
+
+	@Override
+	public boolean isTest() {
+		return false;
+	}
+}
+
+class LeafDescriptor extends AbstractTestDescriptor {
+
+	LeafDescriptor(String uniqueId) {
+		super(uniqueId);
+	}
+
+	@Override
+	public String getDisplayName() {
+		return "leave: " + getUniqueId();
+	}
+
+	@Override
+	public boolean isTest() {
+		return true;
+	}
+}

--- a/junit-engine-api/src/test/java/org/junit/gen5/engine/AbstractTestDescriptorTest.java
+++ b/junit-engine-api/src/test/java/org/junit/gen5/engine/AbstractTestDescriptorTest.java
@@ -61,21 +61,21 @@ public class AbstractTestDescriptorTest {
 	@Test
 	public void visitAllNodes() {
 		List<TestDescriptor> visited = new ArrayList<>();
-		engineDescriptor.accept(visited::add);
+		engineDescriptor.accept((descriptor, delete) -> visited.add(descriptor));
 
 		Assert.assertEquals(8, visited.size());
 	}
 
 	@Test
 	public void pruneLeaf() {
-		TestDescriptor.Visitor visitor = (TestDescriptor descriptor) -> {
+		TestDescriptor.Visitor visitor = (TestDescriptor descriptor, Runnable delete) -> {
 			if (descriptor.getUniqueId().equals("leaf1-1"))
-				descriptor.remove();
+				delete.run();
 		};
 		engineDescriptor.accept(visitor);
 
 		List<String> visited = new ArrayList<>();
-		engineDescriptor.accept((descriptor) -> visited.add(descriptor.getUniqueId()));
+		engineDescriptor.accept((descriptor, delete) -> visited.add(descriptor.getUniqueId()));
 
 		Assert.assertEquals(7, visited.size());
 		Assert.assertTrue(visited.contains("group1"));
@@ -85,9 +85,9 @@ public class AbstractTestDescriptorTest {
 	@Test
 	public void pruneGroup() {
 		final AtomicInteger countVisited = new AtomicInteger();
-		TestDescriptor.Visitor visitor = (TestDescriptor descriptor) -> {
+		TestDescriptor.Visitor visitor = (descriptor, delete) -> {
 			if (descriptor.getUniqueId().equals("group1"))
-				descriptor.remove();
+				delete.run();
 			countVisited.incrementAndGet();
 		};
 		engineDescriptor.accept(visitor);
@@ -95,7 +95,7 @@ public class AbstractTestDescriptorTest {
 		Assert.assertEquals("Children of pruned element are not visited", 4, countVisited.get());
 
 		List<String> visited = new ArrayList<>();
-		engineDescriptor.accept((descriptor) -> visited.add(descriptor.getUniqueId()));
+		engineDescriptor.accept((descriptor, delete) -> visited.add(descriptor.getUniqueId()));
 
 		Assert.assertEquals(3, visited.size());
 		Assert.assertFalse(visited.contains("group1"));

--- a/junit-engine-api/src/test/java/org/junit/gen5/engine/AbstractTestDescriptorTest.java
+++ b/junit-engine-api/src/test/java/org/junit/gen5/engine/AbstractTestDescriptorTest.java
@@ -11,7 +11,6 @@
 package org.junit.gen5.engine;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -28,9 +27,7 @@ public class AbstractTestDescriptorTest {
 		engineDescriptor = new EngineDescriptor(new TestEngine() {
 
 			@Override
-			public Collection<TestDescriptor> discoverTests(TestPlanSpecification specification,
-					EngineDescriptor engineDescriptor) {
-				return null;
+			public void discoverTests(TestPlanSpecification specification, EngineDescriptor engineDescriptor) {
 			}
 
 			@Override

--- a/junit-engine-api/src/test/java/org/junit/gen5/engine/AbstractTestDescriptorTest.java
+++ b/junit-engine-api/src/test/java/org/junit/gen5/engine/AbstractTestDescriptorTest.java
@@ -1,9 +1,20 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
 package org.junit.gen5.engine;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,11 +26,13 @@ public class AbstractTestDescriptorTest {
 	@Before
 	public void initTree() {
 		engineDescriptor = new EngineDescriptor(new TestEngine() {
+
 			@Override
 			public Collection<TestDescriptor> discoverTests(TestPlanSpecification specification,
-				EngineDescriptor engineDescriptor) {
+					EngineDescriptor engineDescriptor) {
 				return null;
 			}
+
 			@Override
 			public void execute(EngineExecutionContext context) {
 
@@ -87,7 +100,6 @@ public class AbstractTestDescriptorTest {
 		Assert.assertEquals(3, visited.size());
 		Assert.assertFalse(visited.contains("group1"));
 	}
-
 
 }
 

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/Launcher.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/Launcher.java
@@ -12,11 +12,7 @@ package org.junit.gen5.launcher;
 
 import static org.junit.gen5.launcher.TestEngineRegistry.lookupAllTestEngines;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 import org.junit.gen5.engine.EngineDescriptor;
 import org.junit.gen5.engine.EngineExecutionContext;
@@ -42,34 +38,40 @@ public class Launcher {
 		TestPlan testPlan = new TestPlan();
 		for (TestEngine testEngine : lookupAllTestEngines()) {
 			EngineDescriptor engineDescriptor = new EngineDescriptor(testEngine);
-			Collection<TestDescriptor> testDescriptors = testEngine.discoverTests(specification, engineDescriptor);
-			if (!testDescriptors.isEmpty()) {
-				Set<TestDescriptor> descriptorCandidates = findFilteredCandidates(specification, testDescriptors);
-				descriptorCandidates.add(engineDescriptor);
-				Set<TestDescriptor> prunedDescriptors = pruneAllWithoutConcreteTests(descriptorCandidates);
-				testPlan.addTestDescriptors(prunedDescriptors);
-			}
+			testEngine.discoverTests(specification, engineDescriptor);
+			applyFiltersToEngineDescriptor(specification, engineDescriptor);
+			pruneEngineDescriptor(engineDescriptor);
+			testPlan.addEngineDescriptor(engineDescriptor);
 		}
 		return testPlan;
 	}
 
-	protected Set<TestDescriptor> findFilteredCandidates(TestPlanSpecification specification,
-			Collection<TestDescriptor> testDescriptors) {
-		// @formatter:off
-		return testDescriptors.stream()
-				.filter((descriptor) -> !descriptor.isTest() || specification.acceptDescriptor(descriptor))
-				.collect(Collectors.toSet());
-		// @formatter:on
+	private void applyFiltersToEngineDescriptor(TestPlanSpecification specification,
+			EngineDescriptor engineDescriptor) {
+		TestDescriptor.Visitor filteringVisitor = (descriptor, remove) -> {
+			if (!descriptor.isTest())
+				return;
+			if (!specification.acceptDescriptor(descriptor))
+				remove.run();
+		};
+		engineDescriptor.accept(filteringVisitor);
 	}
 
-	private Set<TestDescriptor> pruneAllWithoutConcreteTests(Set<TestDescriptor> descriptorCandidates) {
-		Set<TestDescriptor> included = new HashSet<>();
-		descriptorCandidates.stream().filter(
-			descriptor -> descriptor.isTest() || included.contains(descriptor)).forEach(descriptor -> {
-				included.add(descriptor);
-				included.add(descriptor.getParent());
-			});
-		return included;
+	private void pruneEngineDescriptor(EngineDescriptor engineDescriptor) {
+		TestDescriptor.Visitor pruningVisitor = (descriptor, remove) -> {
+			if (descriptor.isRoot())
+				return;
+			if (hasTests(descriptor))
+				return;
+			remove.run();
+		};
+		engineDescriptor.accept(pruningVisitor);
+	}
+
+	private boolean hasTests(TestDescriptor descriptor) {
+		if (descriptor.isTest())
+			return true;
+		return descriptor.getChildren().stream().anyMatch(anyDescriptor -> hasTests(anyDescriptor));
 	}
 
 	public void execute(TestPlanSpecification specification) {
@@ -83,8 +85,8 @@ public class Launcher {
 		testPlanExecutionListener.testPlanExecutionStarted(testPlan);
 		for (TestEngine testEngine : lookupAllTestEngines()) {
 			testPlanExecutionListener.testPlanExecutionStartedOnEngine(testPlan, testEngine);
-			List<TestDescriptor> testDescriptors = testPlan.getAllTestDescriptorsForTestEngine(testEngine);
-			testEngine.execute(new EngineExecutionContext(testDescriptors, testExecutionListener));
+			Optional<EngineDescriptor> engineDescriptor = testPlan.getEngineDescriptorFor(testEngine);
+			testEngine.execute(new EngineExecutionContext(engineDescriptor.get(), testExecutionListener));
 			testPlanExecutionListener.testPlanExecutionFinishedOnEngine(testPlan, testEngine);
 		}
 		testPlanExecutionListener.testPlanExecutionFinished(testPlan);

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/Launcher.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/Launcher.java
@@ -39,39 +39,11 @@ public class Launcher {
 		for (TestEngine testEngine : lookupAllTestEngines()) {
 			EngineDescriptor engineDescriptor = new EngineDescriptor(testEngine);
 			testEngine.discoverTests(specification, engineDescriptor);
-			applyFiltersToEngineDescriptor(specification, engineDescriptor);
-			pruneEngineDescriptor(engineDescriptor);
 			testPlan.addEngineDescriptor(engineDescriptor);
 		}
+		testPlan.applyFilters(specification);
+		testPlan.prune();
 		return testPlan;
-	}
-
-	private void applyFiltersToEngineDescriptor(TestPlanSpecification specification,
-			EngineDescriptor engineDescriptor) {
-		TestDescriptor.Visitor filteringVisitor = (descriptor, remove) -> {
-			if (!descriptor.isTest())
-				return;
-			if (!specification.acceptDescriptor(descriptor))
-				remove.run();
-		};
-		engineDescriptor.accept(filteringVisitor);
-	}
-
-	private void pruneEngineDescriptor(EngineDescriptor engineDescriptor) {
-		TestDescriptor.Visitor pruningVisitor = (descriptor, remove) -> {
-			if (descriptor.isRoot())
-				return;
-			if (hasTests(descriptor))
-				return;
-			remove.run();
-		};
-		engineDescriptor.accept(pruningVisitor);
-	}
-
-	private boolean hasTests(TestDescriptor descriptor) {
-		if (descriptor.isTest())
-			return true;
-		return descriptor.getChildren().stream().anyMatch(anyDescriptor -> hasTests(anyDescriptor));
 	}
 
 	public void execute(TestPlanSpecification specification) {

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/TestPlan.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/TestPlan.java
@@ -10,15 +10,12 @@
 
 package org.junit.gen5.launcher;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.singleton;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
+import org.junit.gen5.engine.EngineDescriptor;
 import org.junit.gen5.engine.TestDescriptor;
 import org.junit.gen5.engine.TestEngine;
 
@@ -30,34 +27,27 @@ public final class TestPlan {
 	/**
 	 * List of all TestDescriptors, including children.
 	 */
-	private final Collection<TestDescriptor> testDescriptors = new LinkedList<>();
+	private final Collection<EngineDescriptor> engineDescriptors = new LinkedList<>();
 
 	TestPlan() {
 		/* no-op */
 	}
 
-	public void addTestDescriptor(TestDescriptor testDescriptor) {
-		addTestDescriptors(singleton(testDescriptor));
+	public void addEngineDescriptor(EngineDescriptor engineDescriptor) {
+		engineDescriptors.add(engineDescriptor);
 	}
 
-	public void addTestDescriptors(TestDescriptor... testDescriptors) {
-		addTestDescriptors(asList(testDescriptors));
+	public Collection<TestDescriptor> getEngineDescriptors() {
+		return Collections.unmodifiableCollection(engineDescriptors);
 	}
 
-	public void addTestDescriptors(Collection<TestDescriptor> testDescriptors) {
-		this.testDescriptors.addAll(testDescriptors);
-	}
-
-	public Collection<TestDescriptor> getTestDescriptors() {
-		return Collections.unmodifiableCollection(testDescriptors);
-	}
-
-	public List<TestDescriptor> getAllTestDescriptorsForTestEngine(TestEngine testEngine) {
-		return this.testDescriptors.stream().filter(testEngine::supports).collect(Collectors.toList());
+	public Optional<EngineDescriptor> getEngineDescriptorFor(TestEngine testEngine) {
+		return this.engineDescriptors.stream().filter(
+			descriptor -> descriptor.getEngine().equals(testEngine)).findFirst();
 	}
 
 	public long getNumberOfStaticTests() {
-		return this.testDescriptors.stream().filter(TestDescriptor::isTest).count();
+		return this.engineDescriptors.stream().filter(TestDescriptor::isTest).count();
 	}
 
 }

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/TestPlan.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/TestPlan.java
@@ -12,28 +12,33 @@ package org.junit.gen5.launcher;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.gen5.engine.EngineDescriptor;
 import org.junit.gen5.engine.TestDescriptor;
 import org.junit.gen5.engine.TestEngine;
+import org.junit.gen5.engine.TestPlanSpecification;
+import org.junit.gen5.engine.TestTag;
 
 /**
  * @since 5.0
  */
-public final class TestPlan {
+public final class TestPlan implements TestDescriptor {
 
 	/**
 	 * List of all TestDescriptors, including children.
 	 */
-	private final Collection<EngineDescriptor> engineDescriptors = new LinkedList<>();
+	private final Set<EngineDescriptor> engineDescriptors = new HashSet<>();
 
 	TestPlan() {
 		/* no-op */
 	}
 
 	public void addEngineDescriptor(EngineDescriptor engineDescriptor) {
+		engineDescriptor.setParent(this);
 		engineDescriptors.add(engineDescriptor);
 	}
 
@@ -48,6 +53,79 @@ public final class TestPlan {
 
 	public long getNumberOfStaticTests() {
 		return this.engineDescriptors.stream().filter(TestDescriptor::isTest).count();
+	}
+
+	@Override
+	public String getUniqueId() {
+		return "testplan";
+	}
+
+	@Override
+	public String getDisplayName() {
+		return "testplan";
+	}
+
+	@Override
+	public TestDescriptor getParent() {
+		return null;
+	}
+
+	@Override
+	public boolean isTest() {
+		return false;
+	}
+
+	@Override
+	public Set<TestTag> getTags() {
+		return null;
+	}
+
+	@Override
+	public void addChild(TestDescriptor descriptor) {
+		throw new UnsupportedOperationException("Only use addEngineDescriptor to add children");
+	}
+
+	@Override
+	public void removeChild(TestDescriptor descriptor) {
+		engineDescriptors.remove(descriptor);
+	}
+
+	@Override
+	public Set<TestDescriptor> getChildren() {
+		return Collections.unmodifiableSet(engineDescriptors);
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		visitor.visit(this, () -> {
+			throw new UnsupportedOperationException("It's not possible to remove the whole test plan");
+		});
+		new HashSet<>(engineDescriptors).forEach(child -> child.accept(visitor));
+	}
+
+	void applyFilters(TestPlanSpecification specification) {
+		Visitor filteringVisitor = (descriptor, remove) -> {
+			if (!descriptor.isTest())
+				return;
+			if (!specification.acceptDescriptor(descriptor))
+				remove.run();
+		};
+		accept(filteringVisitor);
+	}
+
+	void prune() {
+		Visitor pruningVisitor = (descriptor, remove) -> {
+			if (descriptor.isRoot() || descriptor.hasTests())
+				return;
+			remove.run();
+		};
+		accept(pruningVisitor);
+	}
+
+	private boolean hasTests(TestDescriptor descriptor) {
+		if (descriptor.isTest())
+			return true;
+		return descriptor.getChildren().stream().anyMatch(anyDescriptor -> hasTests(anyDescriptor));
 	}
 
 }

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/TestPlan.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/TestPlan.java
@@ -13,7 +13,6 @@ package org.junit.gen5.launcher;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -66,8 +65,8 @@ public final class TestPlan implements TestDescriptor {
 	}
 
 	@Override
-	public TestDescriptor getParent() {
-		return null;
+	public Optional<TestDescriptor> getParent() {
+		return Optional.empty();
 	}
 
 	@Override

--- a/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/DescriptionTestDescriptor.java
+++ b/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/DescriptionTestDescriptor.java
@@ -12,18 +12,20 @@ package org.junit.gen5.engine.junit4;
 
 import java.util.Collections;
 import java.util.Set;
-
-import lombok.Data;
-
+import org.junit.gen5.engine.AbstractTestDescriptor;
 import org.junit.gen5.engine.TestDescriptor;
 import org.junit.gen5.engine.TestTag;
 import org.junit.runner.Description;
 
-@Data
-class DescriptionTestDescriptor implements TestDescriptor {
+class DescriptionTestDescriptor extends AbstractTestDescriptor {
 
-	private final TestDescriptor parent;
 	private final Description description;
+
+	DescriptionTestDescriptor(TestDescriptor parent, Description description) {
+		super("junit4:" + description.getDisplayName());
+		parent.addChild(this);
+		this.description = description;
+	}
 
 	@Override
 	public boolean isTest() {
@@ -36,18 +38,11 @@ class DescriptionTestDescriptor implements TestDescriptor {
 	}
 
 	@Override
-	public String getUniqueId() {
-		// TODO Use unique ID if set, too
-		return "junit4:" + description.getDisplayName();
-	}
-
-	@Override
-	public TestDescriptor getParent() {
-		return parent;
-	}
-
-	@Override
 	public String getDisplayName() {
 		return description.getDisplayName();
+	}
+
+	public Description getDescription() {
+		return description;
 	}
 }

--- a/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/DescriptionTestDescriptor.java
+++ b/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/DescriptionTestDescriptor.java
@@ -12,6 +12,7 @@ package org.junit.gen5.engine.junit4;
 
 import java.util.Collections;
 import java.util.Set;
+
 import org.junit.gen5.engine.AbstractTestDescriptor;
 import org.junit.gen5.engine.TestDescriptor;
 import org.junit.gen5.engine.TestTag;

--- a/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/DescriptionTestDescriptor.java
+++ b/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/DescriptionTestDescriptor.java
@@ -10,14 +10,21 @@
 
 package org.junit.gen5.engine.junit4;
 
-import lombok.Value;
-
 import org.junit.runner.Description;
 
-@Value
-class DescriptionTestDescriptor implements JUnit4TestDescriptor {
+class DescriptionTestDescriptor extends JUnit4TestDescriptor {
 
-	JUnit4TestDescriptor parent;
-	Description description;
+	final Description description;
 
+	DescriptionTestDescriptor(Description description) {
+		// TODO Use unique ID if set, too
+		super(ENGINE_ID + ":" + description.getDisplayName());
+		this.description = description;
+
+	}
+
+	@Override
+	public Description getDescription() {
+		return description;
+	}
 }

--- a/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/JUnit4SpecificationResolver.java
+++ b/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/JUnit4SpecificationResolver.java
@@ -49,14 +49,18 @@ class JUnit4SpecificationResolver implements TestPlanSpecificationVisitor {
 
 		// TODO This skips malformed JUnit 4 tests, too
 		if (!(runner instanceof ErrorReportingRunner)) {
-			addRecursively(new RunnerTestDescriptor(engineDescriptor, runner));
+			RunnerTestDescriptor testDescriptor = new RunnerTestDescriptor(runner);
+			engineDescriptor.addChild(testDescriptor);
+			addRecursively(testDescriptor);
 		}
 	}
 
 	private void addRecursively(JUnit4TestDescriptor parent) {
 		testDescriptors.add(parent);
 		for (Description child : parent.getDescription().getChildren()) {
-			addRecursively(new DescriptionTestDescriptor(parent, child));
+			DescriptionTestDescriptor testDescriptor = new DescriptionTestDescriptor(child);
+			parent.addChild(testDescriptor);
+			addRecursively(testDescriptor);
 		}
 	}
 }

--- a/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/JUnit4TestDescriptor.java
+++ b/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/JUnit4TestDescriptor.java
@@ -14,35 +14,34 @@ import static java.util.Collections.emptySet;
 
 import java.util.Set;
 
+import org.junit.gen5.engine.AbstractTestDescriptor;
 import org.junit.gen5.engine.TestDescriptor;
 import org.junit.gen5.engine.TestTag;
 import org.junit.runner.Description;
 
-interface JUnit4TestDescriptor extends TestDescriptor {
+abstract class JUnit4TestDescriptor extends AbstractTestDescriptor {
 
-	String ENGINE_ID = "junit4";
+	public static String ENGINE_ID = "junit4";
 
-	@Override
-	public default String getUniqueId() {
-		// TODO Use unique ID if set, too
-		return ENGINE_ID + ":" + getDescription().getDisplayName();
+	protected JUnit4TestDescriptor(String uniqueId) {
+		super(uniqueId);
 	}
 
 	@Override
-	public default String getDisplayName() {
+	public String getDisplayName() {
 		return getDescription().getDisplayName();
 	}
 
 	@Override
-	public default boolean isTest() {
+	public boolean isTest() {
 		return getDescription().isTest();
 	}
 
 	@Override
-	public default Set<TestTag> getTags() {
+	public Set<TestTag> getTags() {
 		return emptySet();
 	}
 
-	Description getDescription();
+	public abstract Description getDescription();
 
 }

--- a/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/JUnit4TestDescriptor.java
+++ b/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/JUnit4TestDescriptor.java
@@ -20,7 +20,6 @@ import java.util.Set;
 
 import org.junit.gen5.engine.AbstractTestDescriptor;
 import org.junit.gen5.engine.JavaSource;
-import org.junit.gen5.engine.TestDescriptor;
 import org.junit.gen5.engine.TestSource;
 import org.junit.gen5.engine.TestTag;
 import org.junit.runner.Description;

--- a/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/JUnit4TestEngine.java
+++ b/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/JUnit4TestEngine.java
@@ -13,6 +13,7 @@ package org.junit.gen5.engine.junit4;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.*;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -79,14 +80,13 @@ public class JUnit4TestEngine implements TestEngine {
 	}
 
 	@Override
-	public boolean supports(TestDescriptor testDescriptor) {
-		return testDescriptor instanceof DescriptionTestDescriptor;
-	}
-
-	@Override
 	public void execute(EngineExecutionContext context) {
+
+		//Todo: Use capabilities of engine node to build up tree or to visit nodes
+		List<TestDescriptor> originalTestDescriptors = new ArrayList<>(context.getEngineDescriptor().allChildren());
+
 		//@formatter:off
-		Map<RunnerTestDescriptor, List<DescriptionTestDescriptor>> groupedByRunner = context.getEngineDescriptor().allChildren().stream()
+		Map<RunnerTestDescriptor, List<DescriptionTestDescriptor>> groupedByRunner = originalTestDescriptors.stream()
 			.filter(testDescriptor -> !(testDescriptor instanceof RunnerTestDescriptor))
 			.map(testDescriptor -> (DescriptionTestDescriptor) testDescriptor)
 			.collect(groupingBy(testDescriptor -> findRunner(testDescriptor)));

--- a/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/JUnit4TestEngine.java
+++ b/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/JUnit4TestEngine.java
@@ -38,8 +38,7 @@ public class JUnit4TestEngine implements TestEngine {
 	}
 
 	@Override
-	public void discoverTests(TestPlanSpecification specification,
-			EngineDescriptor engineDescriptor) {
+	public void discoverTests(TestPlanSpecification specification, EngineDescriptor engineDescriptor) {
 		JUnit4SpecificationResolver resolver = new JUnit4SpecificationResolver(engineDescriptor);
 		specification.accept(resolver);
 	}
@@ -92,7 +91,7 @@ public class JUnit4TestEngine implements TestEngine {
 			return (RunnerTestDescriptor) testDescriptor;
 		}
 		if (testDescriptor instanceof DescriptionTestDescriptor) {
-			return findRunnerTestDescriptor(((DescriptionTestDescriptor) testDescriptor).getParent().get());
+			return findRunnerTestDescriptor((JUnit4TestDescriptor) testDescriptor.getParent().get());
 		}
 		throw new IllegalStateException("Cannot handle testDescriptor of class " + testDescriptor.getClass().getName());
 	}

--- a/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/JUnit4TestEngine.java
+++ b/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/JUnit4TestEngine.java
@@ -126,7 +126,7 @@ public class JUnit4TestEngine implements TestEngine {
 		if (testDescriptor instanceof RunnerTestDescriptor) {
 			return (RunnerTestDescriptor) testDescriptor;
 		}
-		return findRunner(testDescriptor.getParent());
+		return findRunner(testDescriptor.getParent().get());
 	}
 
 }

--- a/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/JUnit4TestEngine.java
+++ b/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/JUnit4TestEngine.java
@@ -13,7 +13,6 @@ package org.junit.gen5.engine.junit4;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.*;
 
-import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -45,8 +44,8 @@ public class JUnit4TestEngine implements TestEngine {
 	}
 
 	@Override
-	public Collection<TestDescriptor> discoverTests(TestPlanSpecification specification,
-			EngineDescriptor engineDescriptor) {
+	public void discoverTests(TestPlanSpecification specification, EngineDescriptor engineDescriptor) {
+		//Todo: result is no longer needed
 		Set<TestDescriptor> result = new LinkedHashSet<>();
 		for (TestPlanSpecificationElement element : specification) {
 			if (element instanceof ClassNameSpecification) {
@@ -70,7 +69,6 @@ public class JUnit4TestEngine implements TestEngine {
 				}
 			}
 		}
-		return result;
 	}
 
 	private void addRecursively(DescriptionTestDescriptor parent, Set<TestDescriptor> result) {
@@ -88,7 +86,7 @@ public class JUnit4TestEngine implements TestEngine {
 	@Override
 	public void execute(EngineExecutionContext context) {
 		//@formatter:off
-		Map<RunnerTestDescriptor, List<DescriptionTestDescriptor>> groupedByRunner = context.getTestDescriptors().stream()
+		Map<RunnerTestDescriptor, List<DescriptionTestDescriptor>> groupedByRunner = context.getEngineDescriptor().allChildren().stream()
 			.filter(testDescriptor -> !(testDescriptor instanceof RunnerTestDescriptor))
 			.map(testDescriptor -> (DescriptionTestDescriptor) testDescriptor)
 			.collect(groupingBy(testDescriptor -> findRunner(testDescriptor)));

--- a/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/RunnerTestDescriptor.java
+++ b/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/RunnerTestDescriptor.java
@@ -16,15 +16,22 @@ import org.junit.gen5.engine.EngineDescriptor;
 import org.junit.runner.Description;
 import org.junit.runner.Runner;
 
-@Value
-class RunnerTestDescriptor implements JUnit4TestDescriptor {
+class RunnerTestDescriptor extends JUnit4TestDescriptor {
 
-	EngineDescriptor parent;
-	Runner runner;
+	final Runner runner;
+
+	RunnerTestDescriptor(Runner runner) {
+		// TODO Use unique ID if set, too
+		super(ENGINE_ID + ":" + runner.getDescription().getDisplayName());
+		this.runner = runner;
+	}
 
 	@Override
 	public Description getDescription() {
 		return runner.getDescription();
 	}
 
+	public Runner getRunner() {
+		return runner;
+	}
 }

--- a/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/RunnerTestDescriptor.java
+++ b/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/RunnerTestDescriptor.java
@@ -10,14 +10,9 @@
 
 package org.junit.gen5.engine.junit4;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-
 import org.junit.gen5.engine.TestDescriptor;
 import org.junit.runner.Runner;
 
-@Data
-@EqualsAndHashCode(callSuper = false)
 class RunnerTestDescriptor extends DescriptionTestDescriptor {
 
 	private Runner runner;
@@ -27,4 +22,7 @@ class RunnerTestDescriptor extends DescriptionTestDescriptor {
 		this.runner = runner;
 	}
 
+	public Runner getRunner() {
+		return runner;
+	}
 }

--- a/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/RunnerTestDescriptor.java
+++ b/junit4-engine/src/main/java/org/junit/gen5/engine/junit4/RunnerTestDescriptor.java
@@ -22,7 +22,7 @@ class RunnerTestDescriptor extends JUnit4TestDescriptor {
 
 	Description description;
 
-	public RunnerTestDescriptor(Runner runner) {
+	RunnerTestDescriptor(Runner runner) {
 		// TODO Use unique ID if set, too
 		super(ENGINE_ID + ":" + runner.getDescription().getDisplayName());
 		this.runner = runner;

--- a/junit4-launcher-runner/src/main/java/org/junit/gen5/junit4runner/JUnit5RunnerListener.java
+++ b/junit4-launcher-runner/src/main/java/org/junit/gen5/junit4runner/JUnit5RunnerListener.java
@@ -81,11 +81,7 @@ class JUnit5RunnerListener implements TestPlanExecutionListener {
 	}
 
 	private Description findJUnit4Description(TestDescriptor testDescriptor) {
-		Description description = testTree.getDescription(testDescriptor);
-		if (description == null) {
-			description = testTree.addDescriptionFor(testDescriptor);
-		}
-		return description;
+		return testTree.getDescription(testDescriptor);
 	}
 
 }

--- a/junit4-launcher-runner/src/main/java/org/junit/gen5/junit4runner/JUnit5TestTree.java
+++ b/junit4-launcher-runner/src/main/java/org/junit/gen5/junit4runner/JUnit5TestTree.java
@@ -45,7 +45,7 @@ class JUnit5TestTree {
 	}
 
 	private void buildDescriptionTree(Description suiteDescription, TestPlan plan) {
-		for (TestDescriptor descriptor : plan.getTestDescriptors()) {
+		for (TestDescriptor descriptor : plan.getEngineDescriptors()) {
 			addDescriptionFor(descriptor, suiteDescription);
 		}
 	}

--- a/junit4-launcher-runner/src/main/java/org/junit/gen5/junit4runner/JUnit5TestTree.java
+++ b/junit4-launcher-runner/src/main/java/org/junit/gen5/junit4runner/JUnit5TestTree.java
@@ -54,7 +54,7 @@ class JUnit5TestTree {
 
 	private Description createJUnit4Description(TestDescriptor testDescriptor) {
 		if (testDescriptor.isTest()) {
-			return Description.createTestDescription(testDescriptor.getParent().getDisplayName(),
+			return Description.createTestDescription(testDescriptor.getParent().get().getDisplayName(),
 				testDescriptor.getDisplayName(), testDescriptor.getUniqueId());
 		}
 		else {

--- a/junit4-launcher-runner/src/main/java/org/junit/gen5/junit4runner/JUnit5TestTree.java
+++ b/junit4-launcher-runner/src/main/java/org/junit/gen5/junit4runner/JUnit5TestTree.java
@@ -30,10 +30,6 @@ class JUnit5TestTree {
 		return suiteDescription;
 	}
 
-	Description addDescriptionFor(TestDescriptor descriptor) {
-		return addDescriptionFor(descriptor, suiteDescription);
-	}
-
 	Description getDescription(TestDescriptor testDescriptor) {
 		return descriptions.get(testDescriptor);
 	}
@@ -45,24 +41,15 @@ class JUnit5TestTree {
 	}
 
 	private void buildDescriptionTree(Description suiteDescription, TestPlan plan) {
-		for (TestDescriptor descriptor : plan.getEngineDescriptors()) {
-			addDescriptionFor(descriptor, suiteDescription);
-		}
+		plan.getEngineDescriptors().stream().forEach(
+			testDescriptor -> buildDescription(testDescriptor, suiteDescription));
 	}
 
-	private Description addDescriptionFor(TestDescriptor descriptor, Description root) {
-		if (descriptions.containsKey(descriptor))
-			return descriptions.get(descriptor);
+	private void buildDescription(TestDescriptor descriptor, Description parent) {
 		Description newDescription = createJUnit4Description(descriptor);
+		parent.addChild(newDescription);
 		descriptions.put(descriptor, newDescription);
-		if (descriptor.getParent() == null) {
-			root.addChild(newDescription);
-		}
-		else {
-			Description parent = addDescriptionFor(descriptor.getParent(), root);
-			parent.addChild(newDescription);
-		}
-		return newDescription;
+		descriptor.getChildren().stream().forEach(testDescriptor -> buildDescription(testDescriptor, newDescription));
 	}
 
 	private Description createJUnit4Description(TestDescriptor testDescriptor) {

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
@@ -12,7 +12,9 @@ package org.junit.gen5.engine.junit5;
 
 import static java.util.stream.Collectors.toList;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -43,75 +45,33 @@ public class JUnit5TestEngine implements TestEngine {
 		Preconditions.notNull(specification, "specification must not be null");
 		Preconditions.notNull(engineDescriptor, "engineDescriptor must not be null");
 
-		// TODO Avoid redundant creation of TestDescriptors during this phase
-		Set<TestDescriptor> testDescriptors = new LinkedHashSet<>();
-		// Todo: testDescriptors are no longer needed
-		resolveSpecification(specification, engineDescriptor, testDescriptors);
+		resolveSpecification(specification, engineDescriptor);
 	}
 
-	// Isolated this step to allow easier experimentation / branching / pull requesting
-	private void resolveSpecification(TestPlanSpecification specification, EngineDescriptor engineDescriptor,
-			Set<TestDescriptor> testDescriptors) {
-		SpecificationResolver resolver = new SpecificationResolver(testDescriptors, engineDescriptor);
+	private void resolveSpecification(TestPlanSpecification specification, EngineDescriptor engineDescriptor) {
+		SpecificationResolver resolver = new SpecificationResolver(new HashSet<>(), engineDescriptor);
 		for (TestPlanSpecificationElement element : specification) {
 			resolver.resolveElement(element);
 		}
 	}
 
 	@Override
-	public boolean supports(TestDescriptor testDescriptor) {
-		// TODO Consider creating a superclass or marker interface for JUnit 5 test
-		// descriptors.
-		return testDescriptor.getUniqueId().startsWith(getId());
-	}
-
-	@Override
 	public void execute(EngineExecutionContext context) {
 
-		Map<TestDescriptor, TestExecutionNode> nodes = buildTestExecutionNodesTree(context);
-
-		List<TestExecutionNode> rootNodes = findRootNodes(nodes);
-
-		startRootNodesExecution(context, rootNodes);
+		TestExecutionNode rootNode = buildExecutionTree(context.getEngineDescriptor());
+		rootNode.execute(context);
 	}
 
-	private void startRootNodesExecution(EngineExecutionContext context, List<TestExecutionNode> rootNodes) {
-		for (TestExecutionNode rootNode : rootNodes) {
-			rootNode.execute(context);
-		}
+	private TestExecutionNode buildExecutionTree(EngineDescriptor engineDescriptor) {
+		return buildExecutionNode(engineDescriptor, null);
 	}
 
-	private List<TestExecutionNode> findRootNodes(Map<TestDescriptor, TestExecutionNode> nodes) {
-		List<TestExecutionNode> rootNodes = new LinkedList<>();
-		for (TestExecutionNode node : nodes.values()) {
-
-			TestDescriptor currentTestDescriptor = node.getTestDescriptor();
-			if (currentTestDescriptor.getParent() == null) {
-				rootNodes.add(node);
-			}
-		}
-		return rootNodes;
-	}
-
-	private Map<TestDescriptor, TestExecutionNode> buildTestExecutionNodesTree(EngineExecutionContext context) {
-		Map<TestDescriptor, TestExecutionNode> nodes = new HashMap<>();
-		for (TestDescriptor testDescriptor : context.getEngineDescriptor().allChildren()) {
-			nodes.put(testDescriptor, TestExecutionNodeResolver.forDescriptor(testDescriptor));
-		}
-
-		for (TestExecutionNode node : nodes.values()) {
-
-			TestDescriptor currentTestDescriptor = node.getTestDescriptor();
-
-			// @formatter:off
-			List<TestExecutionNode> childrenForCurrentNode = context.getEngineDescriptor().allChildren().stream()
-					.filter(testDescriptor -> currentTestDescriptor.equals(testDescriptor.getParent()))
-					.map(testDescriptor -> nodes.get(testDescriptor))
-					.collect(toList());
-			// @formatter:on
-			node.addChildren(childrenForCurrentNode);
-		}
-		return nodes;
+	private TestExecutionNode buildExecutionNode(TestDescriptor descriptor, TestExecutionNode parent) {
+		TestExecutionNode newNode = TestExecutionNodeResolver.forDescriptor(descriptor);
+		if (parent != null)
+			parent.addChild(newNode);
+		descriptor.getChildren().stream().forEach(testDescriptor -> buildExecutionNode(testDescriptor, newNode));
+		return newNode;
 	}
 
 }

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
@@ -12,7 +12,6 @@ package org.junit.gen5.engine.junit5;
 
 import static java.util.stream.Collectors.toList;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -40,14 +39,14 @@ public class JUnit5TestEngine implements TestEngine {
 	}
 
 	@Override
-	public List<TestDescriptor> discoverTests(TestPlanSpecification specification, EngineDescriptor engineDescriptor) {
+	public void discoverTests(TestPlanSpecification specification, EngineDescriptor engineDescriptor) {
 		Preconditions.notNull(specification, "specification must not be null");
 		Preconditions.notNull(engineDescriptor, "engineDescriptor must not be null");
 
 		// TODO Avoid redundant creation of TestDescriptors during this phase
 		Set<TestDescriptor> testDescriptors = new LinkedHashSet<>();
+		// Todo: testDescriptors are no longer needed
 		resolveSpecification(specification, engineDescriptor, testDescriptors);
-		return new ArrayList<>(testDescriptors);
 	}
 
 	// Isolated this step to allow easier experimentation / branching / pull requesting
@@ -96,7 +95,7 @@ public class JUnit5TestEngine implements TestEngine {
 
 	private Map<TestDescriptor, TestExecutionNode> buildTestExecutionNodesTree(EngineExecutionContext context) {
 		Map<TestDescriptor, TestExecutionNode> nodes = new HashMap<>();
-		for (TestDescriptor testDescriptor : context.getTestDescriptors()) {
+		for (TestDescriptor testDescriptor : context.getEngineDescriptor().allChildren()) {
 			nodes.put(testDescriptor, TestExecutionNodeResolver.forDescriptor(testDescriptor));
 		}
 
@@ -105,7 +104,7 @@ public class JUnit5TestEngine implements TestEngine {
 			TestDescriptor currentTestDescriptor = node.getTestDescriptor();
 
 			// @formatter:off
-			List<TestExecutionNode> childrenForCurrentNode = context.getTestDescriptors().stream()
+			List<TestExecutionNode> childrenForCurrentNode = context.getEngineDescriptor().allChildren().stream()
 					.filter(testDescriptor -> currentTestDescriptor.equals(testDescriptor.getParent()))
 					.map(testDescriptor -> nodes.get(testDescriptor))
 					.collect(toList());

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
@@ -49,7 +49,7 @@ public class JUnit5TestEngine implements TestEngine {
 	}
 
 	private void resolveSpecification(TestPlanSpecification specification, EngineDescriptor engineDescriptor) {
-		SpecificationResolver resolver = new SpecificationResolver(new HashSet<>(), engineDescriptor);
+		SpecificationResolver resolver = new SpecificationResolver(engineDescriptor);
 		for (TestPlanSpecificationElement element : specification) {
 			resolver.resolveElement(element);
 		}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/ClassTestDescriptor.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/ClassTestDescriptor.java
@@ -25,7 +25,7 @@ import org.junit.gen5.engine.TestTag;
  *
  * @since 5.0
  */
-public class ClassTestDescriptor extends AbstractJUnit5TestDescriptor {
+public class ClassTestDescriptor extends JUnit5TestDescriptor {
 
 	private final String displayName;
 	private final Class<?> testClass;
@@ -45,6 +45,7 @@ public class ClassTestDescriptor extends AbstractJUnit5TestDescriptor {
 		return testClass;
 	}
 
+	@Override
 	public String getDisplayName() {
 		return displayName;
 	}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestDescriptor.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestDescriptor.java
@@ -27,9 +27,9 @@ import org.junit.gen5.engine.TestTag;
  * @author Sam Brannen
  * @since 5.0
  */
-public abstract class AbstractJUnit5TestDescriptor extends AbstractTestDescriptor {
+public abstract class JUnit5TestDescriptor extends AbstractTestDescriptor {
 
-	protected AbstractJUnit5TestDescriptor(String uniqueId) {
+	protected JUnit5TestDescriptor(String uniqueId) {
 		super(uniqueId);
 	}
 

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/MethodTestDescriptor.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/MethodTestDescriptor.java
@@ -24,7 +24,7 @@ import org.junit.gen5.engine.TestTag;
  * @author Sam Brannen
  * @since 5.0
  */
-public class MethodTestDescriptor extends AbstractJUnit5TestDescriptor {
+public class MethodTestDescriptor extends JUnit5TestDescriptor {
 
 	private final String displayName;
 

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/MethodTestDescriptor.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/MethodTestDescriptor.java
@@ -41,9 +41,7 @@ public class MethodTestDescriptor extends AbstractJUnit5TestDescriptor {
 	@Override
 	public Set<TestTag> getTags() {
 		Set<TestTag> methodTags = getTags(this.getTestMethod());
-		if (getParent() != null) {
-			methodTags.addAll(getParent().getTags());
-		}
+		getParent().ifPresent(parentDescriptor -> methodTags.addAll(parentDescriptor.getTags()));
 		return methodTags;
 	}
 

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolver.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolver.java
@@ -13,16 +13,12 @@ package org.junit.gen5.engine.junit5.descriptor;
 import static org.junit.gen5.commons.util.ReflectionUtils.findMethods;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.gen5.commons.util.ReflectionUtils;
 import org.junit.gen5.engine.AbstractTestDescriptor;
 import org.junit.gen5.engine.EngineDescriptor;
-import org.junit.gen5.engine.TestDescriptor;
 import org.junit.gen5.engine.TestPlanSpecificationElement;
 import org.junit.gen5.engine.junit5.testers.CanBeTestClass;
 import org.junit.gen5.engine.junit5.testers.IsTestClassWithTests;
@@ -128,34 +124,13 @@ public class SpecificationResolver {
 	}
 
 	private MethodTestDescriptor getOrCreateMethodDescriptor(Method method, String uniqueId) {
-		MethodTestDescriptor methodTestDescriptor = (MethodTestDescriptor) descriptorByUniqueId(uniqueId);
-		if (methodTestDescriptor == null) {
-			methodTestDescriptor = new MethodTestDescriptor(uniqueId, method);
-		}
-		return methodTestDescriptor;
+		return (MethodTestDescriptor) engineDescriptor.findByUniqueId(uniqueId).orElse(
+			new MethodTestDescriptor(uniqueId, method));
 	}
 
 	private ClassTestDescriptor getOrCreateClassDescriptor(Class<?> clazz, String uniqueId) {
-		ClassTestDescriptor classTestDescriptor = (ClassTestDescriptor) descriptorByUniqueId(uniqueId);
-		if (classTestDescriptor == null) {
-			classTestDescriptor = new ClassTestDescriptor(uniqueId, clazz);
-		}
-		return classTestDescriptor;
-	}
-
-	private TestDescriptor descriptorByUniqueId(String uniqueId) {
-		//Todo: this is inefficient b/c has to visit all test descriptors. May TestDescriptor.childByUniqueId() ?
-		List<TestDescriptor> found = new ArrayList<>();
-		TestDescriptor.Visitor findByUnique = (descriptor, remove) -> {
-			if (descriptor.getUniqueId().equals(uniqueId)) {
-				found.add(descriptor);
-			}
-		};
-		engineDescriptor.accept(findByUnique);
-		if (found.isEmpty())
-			return null;
-		else
-			return found.get(0);
+		return (ClassTestDescriptor) engineDescriptor.findByUniqueId(uniqueId).orElse(
+			new ClassTestDescriptor(uniqueId, clazz));
 	}
 
 	private static void throwCannotResolveMethodException(Method method) {

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/TestExecutionNode.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/TestExecutionNode.java
@@ -28,13 +28,9 @@ public abstract class TestExecutionNode {
 
 	private List<TestExecutionNode> children = new LinkedList<>();
 
-	private void addChild(TestExecutionNode child) {
+	public void addChild(TestExecutionNode child) {
 		this.children.add(child);
 		child.parent = this;
-	}
-
-	public final void addChildren(List<TestExecutionNode> children) {
-		children.forEach(child -> addChild(child));
 	}
 
 	public final TestExecutionNode getParent() {

--- a/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/JUnit5TestEngineTests.java
+++ b/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/JUnit5TestEngineTests.java
@@ -48,13 +48,13 @@ public class JUnit5TestEngineTests {
 		engine = new JUnit5TestEngine();
 	}
 
-	//Todo enable again
+	@org.junit.Test
 	public void executeCompositeTestPlanSpecification() {
 		TestPlanSpecification spec = build(
 			forUniqueId("junit5:org.junit.gen5.engine.junit5.JUnit5TestEngineTests$LocalTestCase#alwaysPasses()"),
 			forClassName(LocalTestCase.class.getName()));
 
-		TrackingTestExecutionListener listener = executeTests(spec, 10);
+		TrackingTestExecutionListener listener = executeTests(spec, 9);
 
 		Assert.assertEquals("# tests started", 8, listener.testStartedCount.get());
 		Assert.assertEquals("# tests succeeded", 4, listener.testSucceededCount.get());
@@ -146,13 +146,11 @@ public class JUnit5TestEngineTests {
 
 	private TrackingTestExecutionListener executeTests(TestPlanSpecification spec, int expectedDescriptorCount) {
 		EngineDescriptor engineDescriptor = discoverTests(spec);
-		Set<TestDescriptor> descriptors = engineDescriptor.allChildren();
-		Assert.assertNotNull(descriptors);
-		Assert.assertEquals("# descriptors", expectedDescriptorCount, descriptors.size());
+		Assert.assertEquals("# descriptors", expectedDescriptorCount, engineDescriptor.allChildren().size());
 
 		TrackingTestExecutionListener listener = new TrackingTestExecutionListener();
 
-		System.out.println("Descriptors: " + descriptors);
+		// System.out.println("Descriptors: " + engineDescriptor.allChildren());
 		engine.execute(new EngineExecutionContext(engineDescriptor, listener));
 
 		Assert.assertTrue("@BeforeAll was not invoked", LocalTestCase.beforeAllInvoked);

--- a/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolverTest.java
+++ b/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolverTest.java
@@ -207,9 +207,9 @@ public class SpecificationResolverTest {
 		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test2()"));
 
 		TestDescriptor classFromMethod1 = descriptorByUniqueId(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()").getParent();
+			"junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()").getParent().get();
 		TestDescriptor classFromMethod2 = descriptorByUniqueId(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test2()").getParent();
+			"junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test2()").getParent().get();
 
 		assertEquals(classFromMethod1, classFromMethod2);
 		assertSame(classFromMethod1, classFromMethod2);

--- a/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolverTest.java
+++ b/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolverTest.java
@@ -27,9 +27,8 @@ import org.junit.gen5.engine.junit5.JUnit5TestEngine;
 
 public class SpecificationResolverTest {
 
-	private final Set<TestDescriptor> descriptors = new HashSet<>();
 	private final EngineDescriptor engineDescriptor = new EngineDescriptor(new JUnit5TestEngine());
-	private SpecificationResolver resolver = new SpecificationResolver(descriptors, engineDescriptor);
+	private SpecificationResolver resolver = new SpecificationResolver(engineDescriptor);
 
 	@org.junit.Test
 	public void testSingleClassNameResolution() {
@@ -37,7 +36,7 @@ public class SpecificationResolverTest {
 
 		resolver.resolveElement(specification);
 
-		assertEquals(3, descriptors.size());
+		assertEquals(3, engineDescriptor.allChildren().size());
 		List<String> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass"));
 		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()"));
@@ -51,8 +50,9 @@ public class SpecificationResolverTest {
 
 		resolver.resolveElement(specification);
 
-		assertEquals(3, descriptors.size());
-		List<String> uniqueIds = descriptors.stream().map(d -> d.getUniqueId()).collect(Collectors.toList());
+		assertEquals(3, engineDescriptor.allChildren().size());
+		List<String> uniqueIds = engineDescriptor.allChildren().stream().map(d -> d.getUniqueId()).collect(
+			Collectors.toList());
 		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass"));
 		assertTrue(uniqueIds.contains(
 			"junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test5()"));
@@ -68,8 +68,9 @@ public class SpecificationResolverTest {
 		resolver.resolveElement(specification1);
 		resolver.resolveElement(specification2);
 
-		assertEquals(6, descriptors.size());
-		List<String> uniqueIds = descriptors.stream().map(d -> d.getUniqueId()).collect(Collectors.toList());
+		assertEquals(6, engineDescriptor.allChildren().size());
+		List<String> uniqueIds = engineDescriptor.allChildren().stream().map(d -> d.getUniqueId()).collect(
+			Collectors.toList());
 		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass"));
 		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()"));
 		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test2()"));
@@ -85,7 +86,7 @@ public class SpecificationResolverTest {
 
 		resolver.resolveElement(specification);
 
-		assertEquals(3, descriptors.size());
+		assertEquals(3, engineDescriptor.allChildren().size());
 		List<String> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass"));
 		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()"));
@@ -99,7 +100,7 @@ public class SpecificationResolverTest {
 
 		resolver.resolveElement(specification);
 
-		assertEquals(3, descriptors.size());
+		assertEquals(3, engineDescriptor.allChildren().size());
 		List<String> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass"));
 		assertTrue(uniqueIds.contains(
@@ -115,7 +116,7 @@ public class SpecificationResolverTest {
 
 		resolver.resolveElement(specification);
 
-		assertEquals(2, descriptors.size());
+		assertEquals(2, engineDescriptor.allChildren().size());
 		List<String> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass"));
 		assertTrue(uniqueIds.contains(
@@ -143,7 +144,7 @@ public class SpecificationResolverTest {
 
 		resolver.resolveElement(specification);
 
-		assertEquals(2, descriptors.size());
+		assertEquals(2, engineDescriptor.allChildren().size());
 		List<String> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass"));
 		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()"));
@@ -156,7 +157,7 @@ public class SpecificationResolverTest {
 
 		resolver.resolveElement(specification);
 
-		assertEquals(2, descriptors.size());
+		assertEquals(2, engineDescriptor.allChildren().size());
 		List<String> uniqueIds = uniqueIds();
 
 		// System.out.println(uniqueIds);
@@ -171,7 +172,7 @@ public class SpecificationResolverTest {
 
 		resolver.resolveElement(specification);
 
-		assertEquals(2, descriptors.size());
+		assertEquals(2, engineDescriptor.allChildren().size());
 		List<String> uniqueIds = uniqueIds();
 
 		// System.out.println(uniqueIds);
@@ -199,7 +200,7 @@ public class SpecificationResolverTest {
 		resolver.resolveElement(specification2);
 		resolver.resolveElement(specification2); // should have no effect
 
-		assertEquals(3, descriptors.size());
+		assertEquals(3, engineDescriptor.allChildren().size());
 		List<String> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass"));
 		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()"));
@@ -220,7 +221,7 @@ public class SpecificationResolverTest {
 			"org.junit.gen5.engine.junit5.descriptor.subpackage");
 		resolver.resolveElement(specification);
 
-		assertEquals(4, descriptors.size());
+		assertEquals(4, engineDescriptor.allChildren().size());
 		List<String> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.subpackage.Class1WithTestCases"));
 		assertTrue(uniqueIds.contains(
@@ -231,11 +232,11 @@ public class SpecificationResolverTest {
 	}
 
 	private TestDescriptor descriptorByUniqueId(String id) {
-		return descriptors.stream().filter(d -> d.getUniqueId().equals(id)).findFirst().get();
+		return engineDescriptor.allChildren().stream().filter(d -> d.getUniqueId().equals(id)).findFirst().get();
 	}
 
 	private List<String> uniqueIds() {
-		return descriptors.stream().map(d -> d.getUniqueId()).collect(Collectors.toList());
+		return engineDescriptor.allChildren().stream().map(d -> d.getUniqueId()).collect(Collectors.toList());
 	}
 
 }

--- a/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/stubs/TestEngineStub.java
+++ b/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/stubs/TestEngineStub.java
@@ -34,11 +34,6 @@ public class TestEngineStub implements TestEngine {
 	}
 
 	@Override
-	public boolean supports(TestDescriptor testDescriptor) {
-		return false;
-	}
-
-	@Override
 	public void execute(EngineExecutionContext context) {
 	}
 }

--- a/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/stubs/TestEngineStub.java
+++ b/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/stubs/TestEngineStub.java
@@ -10,9 +10,11 @@
 
 package org.junit.gen5.engine.junit5.stubs;
 
-import java.util.Collection;
-
-import org.junit.gen5.engine.*;
+import org.junit.gen5.engine.EngineDescriptor;
+import org.junit.gen5.engine.EngineExecutionContext;
+import org.junit.gen5.engine.TestDescriptor;
+import org.junit.gen5.engine.TestEngine;
+import org.junit.gen5.engine.TestPlanSpecification;
 
 /**
  * @author Stefan Bechtold
@@ -28,9 +30,7 @@ public class TestEngineStub implements TestEngine {
 	}
 
 	@Override
-	public Collection<TestDescriptor> discoverTests(TestPlanSpecification specification,
-			EngineDescriptor engineDescriptor) {
-		return null;
+	public void discoverTests(TestPlanSpecification specification, EngineDescriptor engineDescriptor) {
 	}
 
 	@Override

--- a/sample-project/src/test/java/com/example/JUnit4SamplesSuite.java
+++ b/sample-project/src/test/java/com/example/JUnit4SamplesSuite.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 	"junit5:com.example.SampleTestCase#assertAllFailingTest()" })
 @Packages({ "com.example.subpackage" })
 //@OnlyIncludeTags({ "fast" })
-//@OnlyEngine("junit5")
+//@JUnit5.OnlyEngine("junit5")
 public class JUnit4SamplesSuite {
 
 	// When you have the following method, it overrides all annotations

--- a/sample-project/src/test/java/com/example/JUnit4SamplesSuite.java
+++ b/sample-project/src/test/java/com/example/JUnit4SamplesSuite.java
@@ -10,8 +10,6 @@
 
 package com.example;
 
-import static org.junit.gen5.junit4runner.JUnit5.*;
-
 import org.junit.gen5.junit4runner.JUnit5;
 import org.junit.gen5.junit4runner.JUnit5.Classes;
 import org.junit.gen5.junit4runner.JUnit5.Packages;
@@ -23,8 +21,8 @@ import org.junit.runner.RunWith;
 @UniqueIds({ "junit5:com.example.SampleTestCase#assertAllTest()",
 	"junit5:com.example.SampleTestCase#assertAllFailingTest()" })
 @Packages({ "com.example.subpackage" })
-@OnlyIncludeTags({ "fast" })
-@OnlyEngine("junit5")
+//@OnlyIncludeTags({ "fast" })
+//@OnlyEngine("junit5")
 public class JUnit4SamplesSuite {
 
 	// When you have the following method, it overrides all annotations


### PR DESCRIPTION
I used the days to push the idea of an hierarchy of test descriptors further.
Not the engine only gets an EngineDescriptor for resolution and just adds children to it.
This makes a lot of code easier through the whol code base. Especially
- Launcher
- JUnit5TestEngine
- SpecificationResolver
- JUnit5TestTree
JUnit4TestEngine should also become simpler but I haven't had the time to look at it - just did the minimum to keep it working.
If one accepts TestDescription to be a composite, a lot of code can move to the appropriate node types. I only scratched the surface of it.

Please have a look at it and consider it as a basis for discussion.