### PR TITLE
Provide support for nested contexts

### DIFF
--- a/junit-commons/src/main/java/org/junit/gen5/commons/util/ReflectionUtils.java
+++ b/junit-commons/src/main/java/org/junit/gen5/commons/util/ReflectionUtils.java
@@ -15,11 +15,7 @@ import static java.util.stream.Collectors.toList;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -68,6 +64,13 @@ public final class ReflectionUtils {
 
 	public static ClassLoader getClassLoader() {
 		return ClassLoader.getSystemClassLoader();
+	}
+
+	public static List<Class<?>> findClasses(Class<?> clazz, Predicate<Class<?>> predicate) {
+		Preconditions.notNull(clazz, "Class must not be null");
+		Preconditions.notNull(predicate, "predicate must not be null");
+
+		return Arrays.stream(clazz.getClasses()).filter(predicate).collect(Collectors.toList());
 	}
 
 	public static Optional<Method> findMethod(Class<?> clazz, String methodName, Class<?>[] parameterTypes) {

--- a/junit-commons/src/main/java/org/junit/gen5/commons/util/ReflectionUtils.java
+++ b/junit-commons/src/main/java/org/junit/gen5/commons/util/ReflectionUtils.java
@@ -66,11 +66,11 @@ public final class ReflectionUtils {
 		return ClassLoader.getSystemClassLoader();
 	}
 
-	public static List<Class<?>> findClasses(Class<?> clazz, Predicate<Class<?>> predicate) {
+	public static List<Class<?>> findInnerClasses(Class<?> clazz, Predicate<Class<?>> predicate) {
 		Preconditions.notNull(clazz, "Class must not be null");
 		Preconditions.notNull(predicate, "predicate must not be null");
 
-		return Arrays.stream(clazz.getClasses()).filter(predicate).collect(Collectors.toList());
+		return Arrays.stream(clazz.getDeclaredClasses()).filter(predicate).collect(Collectors.toList());
 	}
 
 	public static Optional<Method> findMethod(Class<?> clazz, String methodName, Class<?>[] parameterTypes) {

--- a/junit-console/src/main/java/org/junit/gen5/console/TestSummaryReportingTestListener.java
+++ b/junit-console/src/main/java/org/junit/gen5/console/TestSummaryReportingTestListener.java
@@ -98,7 +98,7 @@ public class TestSummaryReportingTestListener implements TestPlanExecutionListen
 
 	@Override
 	public void testSkipped(TestDescriptor testDescriptor, Throwable t) {
-		this.testsSkipped.incrementAndGet();
+		this.testsSkipped.addAndGet(testDescriptor.getNumberOfStaticTests());
 	}
 
 	@Override

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
@@ -80,4 +80,8 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 		return this.uniqueId.hashCode();
 	}
 
+	@Override
+	public String toString() {
+		return getClass().getSimpleName() + ": " + getUniqueId();
+	}
 }

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/AbstractTestDescriptor.java
@@ -100,6 +100,11 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	}
 
 	@Override
+	public long getNumberOfStaticTests() {
+		return allChildren().stream().filter(TestDescriptor::isTest).count();
+	}
+
+	@Override
 	public Set<TestTag> getTags() {
 		return Collections.emptySet();
 	}

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/EngineDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/EngineDescriptor.java
@@ -36,8 +36,4 @@ public class EngineDescriptor extends AbstractTestDescriptor {
 		return engine;
 	}
 
-	public long getNumberOfStaticTests() {
-		return allChildren().stream().filter(TestDescriptor::isTest).count();
-	}
-
 }

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
@@ -45,6 +45,8 @@ public interface TestDescriptor {
 
 	Set<TestDescriptor> getChildren();
 
+	long getNumberOfStaticTests();
+
 	default boolean hasTests() {
 		if (isTest())
 			return true;

--- a/junit5-api/src/main/java/org/junit/gen5/api/Context.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/Context.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.gen5.api;
+
+import java.lang.annotation.*;
+
+/**
+ * @author Stefan Bechtold
+ * @since 5.0
+ */
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Context {
+}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/ContextTestDescriptor.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/ContextTestDescriptor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.gen5.engine.junit5.descriptor;
+
+import java.util.Set;
+
+import org.junit.gen5.commons.util.Preconditions;
+import org.junit.gen5.engine.TestTag;
+
+public class ContextTestDescriptor extends AbstractJUnit5TestDescriptor {
+
+	private final String displayName;
+	private final Class<?> contextClass;
+
+	public ContextTestDescriptor(String uniqueId, Class<?> contextClass) {
+		super(uniqueId);
+		Preconditions.notNull(contextClass, "contextClass must not be null");
+
+		this.contextClass = contextClass;
+
+		this.displayName = determineDisplayName(contextClass, contextClass.getName());
+
+	}
+
+	public Class<?> getContextClass() {
+		return contextClass;
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+
+	@Override
+	public Set<TestTag> getTags() {
+		return getTags(this.contextClass);
+	}
+
+	@Override
+	public final boolean isTest() {
+		return false;
+	}
+
+}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Class.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Class.java
@@ -10,11 +10,6 @@
 
 package org.junit.gen5.engine.junit5.descriptor;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
-
-@Value
-@EqualsAndHashCode(callSuper = false)
 class JUnit5Class extends JUnit5Testable {
 
 	private final Class<?> javaClass;
@@ -22,6 +17,10 @@ class JUnit5Class extends JUnit5Testable {
 	JUnit5Class(String uniqueId, Class<?> javaClass) {
 		super(uniqueId);
 		this.javaClass = javaClass;
+	}
+
+	public Class<?> getJavaClass() {
+		return javaClass;
 	}
 
 	@Override

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Context.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Context.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.gen5.engine.junit5.descriptor;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+import org.junit.gen5.engine.AbstractTestDescriptor;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+class JUnit5Context extends JUnit5Testable {
+
+	private final Class<?> javaClass;
+	private final AbstractTestDescriptor parent;
+
+	JUnit5Context(String uniqueId, Class<?> javaClass, AbstractTestDescriptor parent) {
+		super(uniqueId);
+		this.javaClass = javaClass;
+		this.parent = parent;
+	}
+
+	@Override
+	void accept(Visitor visitor) {
+		visitor.visitContext(getUniqueId(), this.javaClass, this.parent);
+	}
+
+}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Context.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Context.java
@@ -17,20 +17,20 @@ import org.junit.gen5.engine.AbstractTestDescriptor;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
-class JUnit5Context extends JUnit5Testable {
+class JUnit5Context extends JUnit5Class {
 
 	private final Class<?> javaClass;
-	private final AbstractTestDescriptor parent;
+	private final Class<?> containerClass;
 
-	JUnit5Context(String uniqueId, Class<?> javaClass, AbstractTestDescriptor parent) {
-		super(uniqueId);
+	JUnit5Context(String uniqueId, Class<?> javaClass, Class<?> containerClass) {
+		super(uniqueId, javaClass);
 		this.javaClass = javaClass;
-		this.parent = parent;
+		this.containerClass = containerClass;
 	}
 
 	@Override
 	void accept(Visitor visitor) {
-		visitor.visitContext(getUniqueId(), this.javaClass, this.parent);
+		visitor.visitContext(getUniqueId(), this.javaClass, this.containerClass);
 	}
 
 }

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Context.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Context.java
@@ -10,27 +10,21 @@
 
 package org.junit.gen5.engine.junit5.descriptor;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
-
-import org.junit.gen5.engine.AbstractTestDescriptor;
-
-@Value
-@EqualsAndHashCode(callSuper = false)
 class JUnit5Context extends JUnit5Class {
 
-	private final Class<?> javaClass;
 	private final Class<?> containerClass;
 
 	JUnit5Context(String uniqueId, Class<?> javaClass, Class<?> containerClass) {
 		super(uniqueId, javaClass);
-		this.javaClass = javaClass;
 		this.containerClass = containerClass;
 	}
 
 	@Override
 	void accept(Visitor visitor) {
-		visitor.visitContext(getUniqueId(), this.javaClass, this.containerClass);
+		visitor.visitContext(getUniqueId(), getJavaClass(), this.containerClass);
 	}
 
+	public Class<?> getContainerClass() {
+		return containerClass;
+	}
 }

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Testable.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Testable.java
@@ -12,6 +12,8 @@ package org.junit.gen5.engine.junit5.descriptor;
 
 import java.lang.reflect.Method;
 
+import org.junit.gen5.engine.AbstractTestDescriptor;
+
 abstract class JUnit5Testable {
 
 	static JUnit5Testable fromUniqueId(String uniqueId, String engineId) {
@@ -24,6 +26,10 @@ abstract class JUnit5Testable {
 
 	static JUnit5Testable fromClass(Class<?> clazz, String engineId) {
 		return new JUnit5TestableFactory().fromClass(clazz, engineId);
+	}
+
+	public static JUnit5Testable fromContext(Class<?> testClass, AbstractTestDescriptor parent) {
+		return new JUnit5TestableFactory().fromContext(testClass, parent);
 	}
 
 	static JUnit5Testable fromMethod(Method testMethod, Class<?> clazz, String engineId) {
@@ -47,6 +53,8 @@ abstract class JUnit5Testable {
 		void visitClass(String uniqueId, Class<?> testClass);
 
 		void visitMethod(String uniqueId, Method method, Class<?> container);
+
+		void visitContext(String uniqueId, Class<?> javaClass, AbstractTestDescriptor parent);
 	}
 
 }

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Testable.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Testable.java
@@ -28,8 +28,8 @@ abstract class JUnit5Testable {
 		return new JUnit5TestableFactory().fromClass(clazz, engineId);
 	}
 
-	public static JUnit5Testable fromContext(Class<?> testClass, AbstractTestDescriptor parent) {
-		return new JUnit5TestableFactory().fromContext(testClass, parent);
+	public static JUnit5Testable fromContext(Class<?> testClass, Class<?> containerClass, String engineId) {
+		return new JUnit5TestableFactory().fromContext(testClass, containerClass, engineId);
 	}
 
 	static JUnit5Testable fromMethod(Method testMethod, Class<?> clazz, String engineId) {
@@ -54,7 +54,7 @@ abstract class JUnit5Testable {
 
 		void visitMethod(String uniqueId, Method method, Class<?> container);
 
-		void visitContext(String uniqueId, Class<?> javaClass, AbstractTestDescriptor parent);
+		void visitContext(String uniqueId, Class<?> javaClass, Class<?> containerClass);
 	}
 
 }

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Testable.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5Testable.java
@@ -28,10 +28,6 @@ abstract class JUnit5Testable {
 		return new JUnit5TestableFactory().fromClass(clazz, engineId);
 	}
 
-	public static JUnit5Testable fromContext(Class<?> testClass, Class<?> containerClass, String engineId) {
-		return new JUnit5TestableFactory().fromContext(testClass, containerClass, engineId);
-	}
-
 	static JUnit5Testable fromMethod(Method testMethod, Class<?> clazz, String engineId) {
 		return new JUnit5TestableFactory().fromMethod(testMethod, clazz, engineId);
 	}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestableFactory.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestableFactory.java
@@ -10,7 +10,7 @@
 
 package org.junit.gen5.engine.junit5.descriptor;
 
-import static org.junit.gen5.commons.util.ReflectionUtils.*;
+import static org.junit.gen5.commons.util.ReflectionUtils.loadClass;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
@@ -19,10 +19,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
 import org.junit.gen5.commons.util.Preconditions;
 import org.junit.gen5.commons.util.ReflectionUtils;
-import org.junit.gen5.engine.AbstractTestDescriptor;
 
 public class JUnit5TestableFactory {
 
@@ -55,7 +53,7 @@ public class JUnit5TestableFactory {
 		Preconditions.notNull(testClass, "testClass must not be null");
 		Preconditions.notNull(container, "parent must not be null");
 
-		String uniqueId = fromClass(container, engineId) + "$" + testClass.getSimpleName();
+		String uniqueId = fromClass(container, engineId).getUniqueId() + "@" + testClass.getSimpleName();
 		return new JUnit5Context(uniqueId, testClass, container);
 	}
 
@@ -97,6 +95,10 @@ public class JUnit5TestableFactory {
 				case '$':
 					currentJavaContainer = (Class<?>) currentJavaElement;
 					currentJavaElement = findNestedClass(head, (Class<?>) currentJavaElement);
+					break;
+				case '@':
+					currentJavaContainer = (Class<?>) currentJavaElement;
+					currentJavaElement = findNestedContext(head, (Class<?>) currentJavaElement);
 					break;
 				case '#':
 					currentJavaContainer = (Class<?>) currentJavaElement;
@@ -156,6 +158,11 @@ public class JUnit5TestableFactory {
 
 	private Class<?> findNestedClass(String nameExtension, Class<?> containerClass) {
 		String fullClassName = containerClass.getName() + nameExtension;
+		return classByName(fullClassName);
+	}
+
+	private Class<?> findNestedContext(String nameExtension, Class<?> containerClass) {
+		String fullClassName = containerClass.getName() + "$" + nameExtension.substring(1);
 		return classByName(fullClassName);
 	}
 

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestableFactory.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestableFactory.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import org.junit.gen5.commons.util.Preconditions;
 import org.junit.gen5.commons.util.ReflectionUtils;
+import org.junit.gen5.engine.AbstractTestDescriptor;
 
 public class JUnit5TestableFactory {
 
@@ -48,6 +49,14 @@ public class JUnit5TestableFactory {
 		Preconditions.notNull(clazz, "clazz must not be null");
 		String uniqueId = engineId + ":" + clazz.getName();
 		return new JUnit5Class(uniqueId, clazz);
+	}
+
+	public JUnit5Testable fromContext(Class<?> testClass, AbstractTestDescriptor parent) {
+		Preconditions.notNull(testClass, "testClass must not be null");
+		Preconditions.notNull(parent, "parent must not be null");
+
+		String uniqueId = parent.getUniqueId() + "$" + testClass.getSimpleName();
+		return new JUnit5Context(uniqueId, testClass, parent);
 	}
 
 	public JUnit5Testable fromMethod(Method testMethod, Class<?> clazz, String engineId) {
@@ -167,5 +176,4 @@ public class JUnit5TestableFactory {
 		throw new IllegalArgumentException(
 			String.format("Cannot resolve part '%s' of unique id '%s'", uniqueIdPart, fullUniqueId));
 	}
-
 }

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestableFactory.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestableFactory.java
@@ -51,12 +51,12 @@ public class JUnit5TestableFactory {
 		return new JUnit5Class(uniqueId, clazz);
 	}
 
-	public JUnit5Testable fromContext(Class<?> testClass, AbstractTestDescriptor parent) {
+	public JUnit5Testable fromContext(Class<?> testClass, Class<?> container, String engineId) {
 		Preconditions.notNull(testClass, "testClass must not be null");
-		Preconditions.notNull(parent, "parent must not be null");
+		Preconditions.notNull(container, "parent must not be null");
 
-		String uniqueId = parent.getUniqueId() + "$" + testClass.getSimpleName();
-		return new JUnit5Context(uniqueId, testClass, parent);
+		String uniqueId = fromClass(container, engineId) + "$" + testClass.getSimpleName();
+		return new JUnit5Context(uniqueId, testClass, container);
 	}
 
 	public JUnit5Testable fromMethod(Method testMethod, Class<?> clazz, String engineId) {

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolver.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolver.java
@@ -93,8 +93,10 @@ public class SpecificationResolver {
 			}
 
 			@Override
-			public void visitContext(String uniqueId, Class<?> testClass, AbstractTestDescriptor parent) {
-				resolveClass(testClass, uniqueId, parent, true);
+			public void visitContext(String uniqueId, Class<?> testClass, Class<?> containerClass) {
+				//Todo XXXXXXXXX
+				AbstractTestDescriptor container = resolveClass(containerClass, uniqueId, engineDescriptor, false);
+				resolveClass(testClass, uniqueId, container, true);
 			}
 		});
 	}
@@ -122,7 +124,7 @@ public class SpecificationResolver {
 		if (withChildren) {
 			List<Class<?>> testClassCandidates = findClasses(clazz, isTestContext);
 			for (Class<?> testClass : testClassCandidates) {
-				JUnit5Testable contextTestable = JUnit5Testable.fromContext(testClass, descriptor);
+				JUnit5Testable contextTestable = JUnit5Testable.fromContext(testClass, clazz, engineDescriptor.getUniqueId());
 				ClassTestDescriptor context = getOrCreateClassDescriptor(testClass, contextTestable.getUniqueId());
 				parent.addChild(context);
 			}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolver.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolver.java
@@ -122,16 +122,15 @@ public class SpecificationResolver {
 		parent.addChild(descriptor);
 
 		if (withChildren) {
-			List<Class<?>> testClassCandidates = findClasses(clazz, isTestContext);
-			for (Class<?> testClass : testClassCandidates) {
-				JUnit5Testable contextTestable = JUnit5Testable.fromContext(testClass, clazz, engineDescriptor.getUniqueId());
-				ClassTestDescriptor context = getOrCreateClassDescriptor(testClass, contextTestable.getUniqueId());
-				parent.addChild(context);
+			List<Class<?>> contextClasses = findClasses(clazz, isTestContext);
+			for (Class<?> contextClass : contextClasses) {
+				JUnit5Testable contextTestable = JUnit5Testable.fromContext(contextClass, clazz, engineDescriptor.getUniqueId());
+				ClassTestDescriptor context = getOrCreateClassDescriptor(contextClass, contextTestable.getUniqueId());
+				descriptor.addChild(context);
 			}
 
 			List<Method> testMethodCandidates = findMethods(clazz, isTestMethod,
 				ReflectionUtils.MethodSortOrder.HierarchyDown);
-
 			for (Method method : testMethodCandidates) {
 				JUnit5Testable methodTestable = JUnit5Testable.fromMethod(method, clazz,
 					engineDescriptor.getUniqueId());

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolver.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolver.java
@@ -100,14 +100,17 @@ public class SpecificationResolver {
 		});
 	}
 
-	private void resolveContext(Class<?> contextClass, Class<?> containerClass, String uniqueId, AbstractTestDescriptor parent) {
+	private void resolveContext(Class<?> contextClass, Class<?> containerClass, String uniqueId,
+			AbstractTestDescriptor parent) {
 		if (!isTestContext.test(contextClass)) {
 			throwCannotResolveContextException(contextClass);
 		}
-		JUnit5Testable parentId = JUnit5Testable.fromContext(contextClass, containerClass, engineDescriptor.getUniqueId());
+		//Todo: tut noch nicht
+		JUnit5Testable parentId = JUnit5Testable.fromContext(contextClass, containerClass,
+			engineDescriptor.getUniqueId());
 		parent = resolveClass(containerClass, parentId.getUniqueId(), parent, false);
 
-		ClassTestDescriptor descriptor = getOrCreateContextDescriptor(contextClass, uniqueId);
+		ContextTestDescriptor descriptor = getOrCreateContextDescriptor(contextClass, uniqueId);
 		parent.addChild(descriptor);
 		testDescriptors.add(descriptor);
 	}
@@ -135,7 +138,8 @@ public class SpecificationResolver {
 		if (withChildren) {
 			List<Class<?>> contextClasses = findInnerClasses(clazz, isTestContext);
 			for (Class<?> contextClass : contextClasses) {
-				JUnit5Testable contextTestable = JUnit5Testable.fromContext(contextClass, clazz, engineDescriptor.getUniqueId());
+				JUnit5Testable contextTestable = JUnit5Testable.fromContext(contextClass, clazz,
+					engineDescriptor.getUniqueId());
 				ClassTestDescriptor context = getOrCreateClassDescriptor(contextClass, contextTestable.getUniqueId());
 				descriptor.addChild(context);
 			}
@@ -162,13 +166,13 @@ public class SpecificationResolver {
 		return methodTestDescriptor;
 	}
 
-	private ClassTestDescriptor getOrCreateContextDescriptor(Class<?> clazz, String uniqueId) {
-		ClassTestDescriptor classTestDescriptor = (ClassTestDescriptor) descriptorByUniqueId(uniqueId);
-		if (classTestDescriptor == null) {
-			classTestDescriptor = new ClassTestDescriptor(uniqueId, clazz);
-			testDescriptors.add(classTestDescriptor);
+	private ContextTestDescriptor getOrCreateContextDescriptor(Class<?> clazz, String uniqueId) {
+		ContextTestDescriptor contextTestDescriptor = (ContextTestDescriptor) descriptorByUniqueId(uniqueId);
+		if (contextTestDescriptor == null) {
+			contextTestDescriptor = new ContextTestDescriptor(uniqueId, clazz);
+			testDescriptors.add(contextTestDescriptor);
 		}
-		return classTestDescriptor;
+		return contextTestDescriptor;
 	}
 
 	private ClassTestDescriptor getOrCreateClassDescriptor(Class<?> clazz, String uniqueId) {

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolver.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolver.java
@@ -24,6 +24,7 @@ import org.junit.gen5.engine.TestDescriptor;
 import org.junit.gen5.engine.TestPlanSpecificationElement;
 import org.junit.gen5.engine.junit5.testers.CanBeTestClass;
 import org.junit.gen5.engine.junit5.testers.IsTestClassWithTests;
+import org.junit.gen5.engine.junit5.testers.IsTestContext;
 import org.junit.gen5.engine.junit5.testers.IsTestMethod;
 
 public class SpecificationResolver {
@@ -32,6 +33,7 @@ public class SpecificationResolver {
 	private final EngineDescriptor engineDescriptor;
 
 	private final CanBeTestClass canBeTestClass = new CanBeTestClass();
+	private final IsTestContext isTestContext = new IsTestContext();
 	private final IsTestMethod isTestMethod = new IsTestMethod();
 	private final IsTestClassWithTests isTestClassWithTests = new IsTestClassWithTests();
 
@@ -90,6 +92,10 @@ public class SpecificationResolver {
 				resolveMethod(method, container, uniqueId, engineDescriptor);
 			}
 
+			@Override
+			public void visitContext(String uniqueId, Class<?> testClass, AbstractTestDescriptor parent) {
+				resolveClass(testClass, uniqueId, parent, true);
+			}
 		});
 	}
 
@@ -114,6 +120,13 @@ public class SpecificationResolver {
 		parent.addChild(descriptor);
 
 		if (withChildren) {
+			List<Class<?>> testClassCandidates = findClasses(clazz, isTestContext);
+			for (Class<?> testClass : testClassCandidates) {
+				JUnit5Testable contextTestable = JUnit5Testable.fromContext(testClass, descriptor);
+				ClassTestDescriptor context = getOrCreateClassDescriptor(testClass, contextTestable.getUniqueId());
+				parent.addChild(context);
+			}
+
 			List<Method> testMethodCandidates = findMethods(clazz, isTestMethod,
 				ReflectionUtils.MethodSortOrder.HierarchyDown);
 

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/ContextTestExecutionNode.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/ContextTestExecutionNode.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.gen5.engine.junit5.execution;
+
+import static org.junit.gen5.commons.util.AnnotationUtils.findAnnotatedMethods;
+import static org.junit.gen5.commons.util.ReflectionUtils.*;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.gen5.api.AfterAll;
+import org.junit.gen5.api.BeforeAll;
+import org.junit.gen5.commons.util.ReflectionUtils;
+import org.junit.gen5.engine.EngineExecutionContext;
+import org.junit.gen5.engine.junit5.descriptor.ClassTestDescriptor;
+import org.junit.gen5.engine.junit5.descriptor.ContextTestDescriptor;
+import org.opentestalliance.TestSkippedException;
+
+/**
+ * @author Stefan Bechtold
+ * @author Sam Brannen
+ * @since 5.0
+ */
+class ContextTestExecutionNode extends TestExecutionNode {
+
+	static final String TEST_INSTANCE_ATTRIBUTE_NAME = ContextTestExecutionNode.class.getName() + ".TestInstance";
+
+	private final ContextTestDescriptor testDescriptor;
+
+	private final ConditionalEvaluator conditionalEvaluator = new ConditionalEvaluator();
+
+	ContextTestExecutionNode(ContextTestDescriptor testDescriptor) {
+		this.testDescriptor = testDescriptor;
+	}
+
+	//	private Object createTestInstance() {
+	//		try {
+	//			return ReflectionUtils.newInstance(getTestDescriptor().getTestClass());
+	//		}
+	//		catch (InvocationTargetException | NoSuchMethodException | InstantiationException | IllegalAccessException ex) {
+	//			throw new IllegalStateException(
+	//				String.format("Test %s is not well-formed and cannot be executed", getTestDescriptor().getUniqueId()),
+	//				ex);
+	//		}
+	//	}
+
+	@Override
+	public ContextTestDescriptor getTestDescriptor() {
+		return this.testDescriptor;
+	}
+
+	@Override
+	public void execute(EngineExecutionContext context) {
+		throw new TestSkippedException("Not yet able to execute test contexts");
+
+		//		if (!this.conditionalEvaluator.testEnabled(context, getTestDescriptor())) {
+		//			// Abort execution of the test completely at this point.
+		//			return;
+		//		}
+		//
+		//		Class<?> testClass = getTestDescriptor().getTestClass();
+		//		Object testInstance = createTestInstance();
+		//		context.getAttributes().put(TEST_INSTANCE_ATTRIBUTE_NAME, testInstance);
+		//
+		//		try {
+		//			executeBeforeAllMethods(testClass, testInstance);
+		//			for (TestExecutionNode child : getChildren()) {
+		//				child.execute(context);
+		//			}
+		//		}
+		//		catch (Exception e) {
+		//			context.getTestExecutionListener().testFailed(getTestDescriptor(), e);
+		//		}
+		//		finally {
+		//			try {
+		//				executeAfterAllMethods(context, testClass, testInstance);
+		//			}
+		//			finally {
+		//				context.getAttributes().remove(TEST_INSTANCE_ATTRIBUTE_NAME);
+		//			}
+		//		}
+	}
+
+	private void executeBeforeAllMethods(Class<?> testClass, Object testInstance) throws Exception {
+		for (Method method : findAnnotatedMethods(testClass, BeforeAll.class, MethodSortOrder.HierarchyDown)) {
+			invokeMethod(method, testInstance);
+		}
+	}
+
+	private void executeAfterAllMethods(EngineExecutionContext context, Class<?> testClass, Object testInstance) {
+		Exception exceptionDuringAfterAll = null;
+
+		for (Method method : findAnnotatedMethods(testClass, AfterAll.class, MethodSortOrder.HierarchyUp)) {
+			try {
+				invokeMethod(method, testInstance);
+			}
+			catch (Exception e) {
+				if (exceptionDuringAfterAll == null) {
+					exceptionDuringAfterAll = e;
+				}
+				else {
+					exceptionDuringAfterAll.addSuppressed(e);
+				}
+			}
+		}
+
+		if (exceptionDuringAfterAll != null) {
+			context.getTestExecutionListener().testFailed(getTestDescriptor(), exceptionDuringAfterAll);
+		}
+	}
+
+}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/ContextTestExecutionNode.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/ContextTestExecutionNode.java
@@ -54,7 +54,8 @@ class ContextTestExecutionNode extends TestExecutionNode {
 
 	@Override
 	public void execute(EngineExecutionContext context) {
-		throw new TestSkippedException("Not yet able to execute test contexts");
+		TestSkippedException testSkippedException = new TestSkippedException("Not yet able to execute test contexts");
+		context.getTestExecutionListener().testSkipped(getTestDescriptor(), testSkippedException);
 
 		//		if (!this.conditionalEvaluator.testEnabled(context, getTestDescriptor())) {
 		//			// Abort execution of the test completely at this point.

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/TestExecutionNodeResolver.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/TestExecutionNodeResolver.java
@@ -14,6 +14,7 @@ import org.junit.gen5.commons.util.Preconditions;
 import org.junit.gen5.engine.EngineDescriptor;
 import org.junit.gen5.engine.TestDescriptor;
 import org.junit.gen5.engine.junit5.descriptor.ClassTestDescriptor;
+import org.junit.gen5.engine.junit5.descriptor.ContextTestDescriptor;
 import org.junit.gen5.engine.junit5.descriptor.MethodTestDescriptor;
 
 /**
@@ -31,6 +32,9 @@ public class TestExecutionNodeResolver {
 		}
 		else if (testDescriptor instanceof ClassTestDescriptor) {
 			return new ClassTestExecutionNode((ClassTestDescriptor) testDescriptor);
+		}
+		else if (testDescriptor instanceof ContextTestDescriptor) {
+			return new ContextTestExecutionNode((ContextTestDescriptor) testDescriptor);
 		}
 		else if (testDescriptor instanceof EngineDescriptor) {
 			return new EngineTestExecutionNode((EngineDescriptor) testDescriptor);

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/testers/CanBeTestClass.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/testers/CanBeTestClass.java
@@ -19,7 +19,11 @@ public class CanBeTestClass extends ReflectionObjectTester implements Predicate<
 
 	@Override
 	public boolean test(Class<?> testClassCandidate) {
-		return (!isAbstract(testClassCandidate) && !testClassCandidate.isLocalClass());
+		if (isAbstract(testClassCandidate))
+			return false;
+		if (testClassCandidate.isMemberClass() && !isStatic(testClassCandidate))
+			return false;
+		return (!testClassCandidate.isLocalClass());
 	}
 
 }

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/testers/IsTestContext.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/testers/IsTestContext.java
@@ -10,11 +10,8 @@
 
 package org.junit.gen5.engine.junit5.testers;
 
-import java.lang.reflect.Method;
 import java.util.function.Predicate;
-
 import org.junit.gen5.api.Context;
-import org.junit.gen5.api.Test;
 
 /**
  * @author Stefan Bechtold
@@ -26,6 +23,10 @@ public class IsTestContext extends ReflectionObjectTester implements Predicate<C
 	public boolean test(Class<?> contextClassCandidate) {
 		if (isPrivate(contextClassCandidate))
 			return false;
-		return hasAnnotation(contextClassCandidate, Context.class) && contextClassCandidate.isLocalClass();
+		if (!contextClassCandidate.isMemberClass())
+			return false;
+		if (isStatic(contextClassCandidate))
+			return false;
+		return hasAnnotation(contextClassCandidate, Context.class);
 	}
 }

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/testers/IsTestContext.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/testers/IsTestContext.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.gen5.engine.junit5.testers;
+
+import java.lang.reflect.Method;
+import java.util.function.Predicate;
+
+import org.junit.gen5.api.Context;
+import org.junit.gen5.api.Test;
+
+/**
+ * @author Stefan Bechtold
+ * @since 5.0
+ */
+public class IsTestContext extends ReflectionObjectTester implements Predicate<Class<?>> {
+
+	@Override
+	public boolean test(Class<?> testClassCandidate) {
+		if (isPrivate(testClassCandidate))
+			return false;
+		return hasAnnotation(testClassCandidate, Context.class);
+	}
+}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/testers/IsTestContext.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/testers/IsTestContext.java
@@ -11,6 +11,7 @@
 package org.junit.gen5.engine.junit5.testers;
 
 import java.util.function.Predicate;
+
 import org.junit.gen5.api.Context;
 
 /**

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/testers/IsTestContext.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/testers/IsTestContext.java
@@ -23,9 +23,9 @@ import org.junit.gen5.api.Test;
 public class IsTestContext extends ReflectionObjectTester implements Predicate<Class<?>> {
 
 	@Override
-	public boolean test(Class<?> testClassCandidate) {
-		if (isPrivate(testClassCandidate))
+	public boolean test(Class<?> contextClassCandidate) {
+		if (isPrivate(contextClassCandidate))
 			return false;
-		return hasAnnotation(testClassCandidate, Context.class);
+		return hasAnnotation(contextClassCandidate, Context.class) && contextClassCandidate.isLocalClass();
 	}
 }

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/testers/ReflectionObjectTester.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/testers/ReflectionObjectTester.java
@@ -42,4 +42,7 @@ class ReflectionObjectTester {
 		return hasModifier(candidate, Modifier.ABSTRACT);
 	}
 
+	boolean isStatic(Object candidate) {
+		return hasModifier(candidate, Modifier.STATIC);
+	}
 }

--- a/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/JUnit5TestEngineTests.java
+++ b/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/JUnit5TestEngineTests.java
@@ -25,6 +25,7 @@ import org.junit.gen5.api.After;
 import org.junit.gen5.api.AfterAll;
 import org.junit.gen5.api.Before;
 import org.junit.gen5.api.BeforeAll;
+import org.junit.gen5.api.Context;
 import org.junit.gen5.api.Disabled;
 import org.junit.gen5.api.Name;
 import org.junit.gen5.api.Test;
@@ -166,6 +167,26 @@ public class JUnit5TestEngineTests {
 		Assert.assertEquals("# tests failed", 0, listener.testFailedCount.get());
 	}
 
+	@org.junit.Test
+	public void executeTestCaseWithInnerContext() {
+		TestPlanSpecification spec = build(forClassName(TestCaseWithContext.class.getName()));
+
+		EngineDescriptor engineDescriptor = discoverTests(spec);
+		Assert.assertEquals("# descriptors", 4, engineDescriptor.allChildren().size());
+
+		engineDescriptor.allChildren().forEach(testDescriptor -> System.out.println(testDescriptor));
+
+		TrackingTestExecutionListener listener = new TrackingTestExecutionListener();
+
+		engine.execute(new EngineExecutionContext(engineDescriptor, listener));
+
+		Assert.assertEquals("# tests started", 1, listener.testStartedCount.get());
+		Assert.assertEquals("# tests succeeded", 1, listener.testSucceededCount.get());
+		Assert.assertEquals("# tests skipped", 1, listener.testSkippedCount.get());
+		Assert.assertEquals("# tests aborted", 0, listener.testAbortedCount.get());
+		Assert.assertEquals("# tests failed", 0, listener.testFailedCount.get());
+	}
+
 	private TrackingTestExecutionListener executeTests(TestPlanSpecification spec, int expectedDescriptorCount) {
 		EngineDescriptor engineDescriptor = discoverTests(spec);
 		Assert.assertEquals("# descriptors", expectedDescriptorCount, engineDescriptor.allChildren().size());
@@ -297,6 +318,22 @@ public class JUnit5TestEngineTests {
 		void disabledTest() {
 		}
 
+	}
+
+	private static class TestCaseWithContext {
+
+		@Test
+		void enabledTest() {
+		}
+
+		@Context
+		class InnerTestCase {
+
+			@Test
+			void innerTest() {
+				//Currently skipped
+			}
+		}
 	}
 
 	private static class MethodParameterInjectionTestCase {

--- a/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolverTest.java
+++ b/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolverTest.java
@@ -232,22 +232,83 @@ public class SpecificationResolverTest {
 	}
 
 	@org.junit.Test
-	public void testContextResolution() {
+	public void testContextResolutionFromContainerClass() {
 		ClassNameSpecification specification = new ClassNameSpecification(TestCaseWithContexts.class.getName());
+
+		resolver.resolveElement(specification);
+
+		List<String> uniqueIds = descriptors.stream().map(d -> d.getUniqueId()).collect(Collectors.toList());
+		assertEquals(6, uniqueIds.size());
+
+		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts"));
+		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts#testA()"));
+		assertTrue(
+			uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts@InnerContext"));
+		assertTrue(uniqueIds.contains(
+			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts@InnerContext#testB()"));
+		assertTrue(uniqueIds.contains(
+			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts@InnerContext@InnerInnerContext"));
+		assertTrue(uniqueIds.contains(
+			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts@InnerContext@InnerInnerContext#testC()"));
+	}
+
+	@org.junit.Test
+	public void testContextResolutionFromContextClass() {
+		ClassNameSpecification specification = new ClassNameSpecification(
+			TestCaseWithContexts.InnerContext.class.getName());
+
+		resolver.resolveElement(specification);
+
+		List<String> uniqueIds = descriptors.stream().map(d -> d.getUniqueId()).collect(Collectors.toList());
+		assertEquals(5, uniqueIds.size());
+
+		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts"));
+		assertTrue(
+			uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts@InnerContext"));
+		assertTrue(uniqueIds.contains(
+			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts@InnerContext#testB()"));
+		assertTrue(uniqueIds.contains(
+			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts@InnerContext@InnerInnerContext"));
+		assertTrue(uniqueIds.contains(
+			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts@InnerContext@InnerInnerContext#testC()"));
+	}
+
+	@org.junit.Test
+	public void testContextResolutionFromUniqueId() {
+		UniqueIdSpecification specification = new UniqueIdSpecification(
+			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts@InnerContext@InnerInnerContext");
+
+		resolver.resolveElement(specification);
+
+		List<String> uniqueIds = descriptors.stream().map(d -> d.getUniqueId()).collect(Collectors.toList());
+		assertEquals(4, uniqueIds.size());
+
+		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts"));
+		assertTrue(
+			uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts@InnerContext"));
+		assertTrue(uniqueIds.contains(
+			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts@InnerContext@InnerInnerContext"));
+		assertTrue(uniqueIds.contains(
+			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts@InnerContext@InnerInnerContext#testC()"));
+	}
+
+	@org.junit.Test
+	public void testContextResolutionFromUniqueIdToMethod() {
+		UniqueIdSpecification specification = new UniqueIdSpecification(
+			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts@InnerContext#testB()");
 
 		resolver.resolveElement(specification);
 
 		descriptors.forEach(id -> System.out.println(id));
 
 		List<String> uniqueIds = descriptors.stream().map(d -> d.getUniqueId()).collect(Collectors.toList());
+		assertEquals(3, uniqueIds.size());
 
-		assertEquals(6, uniqueIds.size());
-
-		//		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass"));
-		//		assertTrue(uniqueIds.contains(
-		//			"junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test5()"));
-		//		assertTrue(uniqueIds.contains(
-		//			"junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test6()"));
+		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts"));
+		assertTrue(
+			uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts@InnerContext"));
+		assertTrue(uniqueIds.contains(
+			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithContexts@InnerContext#testB()"));
 	}
 
 	private TestDescriptor descriptorByUniqueId(String id) {

--- a/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolverTest.java
+++ b/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolverTest.java
@@ -237,18 +237,17 @@ public class SpecificationResolverTest {
 
 		resolver.resolveElement(specification);
 
+		descriptors.forEach(id -> System.out.println(id));
+
 		List<String> uniqueIds = descriptors.stream().map(d -> d.getUniqueId()).collect(Collectors.toList());
-		uniqueIds().forEach(id ->
-			System.out.println(id)
-		);
 
 		assertEquals(6, uniqueIds.size());
 
-//		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass"));
-//		assertTrue(uniqueIds.contains(
-//			"junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test5()"));
-//		assertTrue(uniqueIds.contains(
-//			"junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test6()"));
+		//		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass"));
+		//		assertTrue(uniqueIds.contains(
+		//			"junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test5()"));
+		//		assertTrue(uniqueIds.contains(
+		//			"junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test6()"));
 	}
 
 	private TestDescriptor descriptorByUniqueId(String id) {

--- a/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolverTest.java
+++ b/junit5-engine/src/test/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolverTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.junit.gen5.api.Context;
 import org.junit.gen5.api.Test;
 import org.junit.gen5.engine.ClassNameSpecification;
 import org.junit.gen5.engine.EngineDescriptor;
@@ -230,6 +231,26 @@ public class SpecificationResolverTest {
 			"junit5:org.junit.gen5.engine.junit5.descriptor.subpackage.Class2WithTestCases#test2()"));
 	}
 
+	@org.junit.Test
+	public void testContextResolution() {
+		ClassNameSpecification specification = new ClassNameSpecification(TestCaseWithContexts.class.getName());
+
+		resolver.resolveElement(specification);
+
+		List<String> uniqueIds = descriptors.stream().map(d -> d.getUniqueId()).collect(Collectors.toList());
+		uniqueIds().forEach(id ->
+			System.out.println(id)
+		);
+
+		assertEquals(6, uniqueIds.size());
+
+//		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass"));
+//		assertTrue(uniqueIds.contains(
+//			"junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test5()"));
+//		assertTrue(uniqueIds.contains(
+//			"junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test6()"));
+	}
+
 	private TestDescriptor descriptorByUniqueId(String id) {
 		return descriptors.stream().filter(d -> d.getUniqueId().equals(id)).findFirst().get();
 	}
@@ -290,6 +311,34 @@ class OtherTestClass {
 
 		@Test
 		void test6() {
+
+		}
+
+	}
+}
+
+class TestCaseWithContexts {
+
+	@Test
+	void testA() {
+
+	}
+
+	@Context
+	class InnerContext {
+
+		@Test
+		void testB() {
+
+		}
+
+		@Context
+		class InnerInnerContext {
+
+			@Test
+			void testC() {
+
+			}
 
 		}
 

--- a/sample-project/build.gradle
+++ b/sample-project/build.gradle
@@ -13,7 +13,7 @@ task runSampleTestCases(type: JavaExec) {
 	classpath = sourceSets.test.runtimeClasspath
 	classpath += project(':junit-console').sourceSets.main.runtimeClasspath
 	main = 'org.junit.gen5.console.ConsoleRunner'
-	args 'com.example.SampleTestCase', 'com.example.SucceedingTestCase', 'com.example.JUnit4TestCase'
+	args 'com.example.SampleTestCase', 'com.example.SucceedingTestCase', 'com.example.JUnit4TestCase', 'com.example.HierarchyTestCase'
 }
 
 test {

--- a/sample-project/src/test/java/com/example/HierarchyTestCase.java
+++ b/sample-project/src/test/java/com/example/HierarchyTestCase.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package com.example;
+
+import org.junit.gen5.api.*;
+
+/**
+ * Named *TestCase so Gradle will not try to run it.
+ *
+ * @author Stefan Bechtold
+ * @since 5.0.0
+ */
+class HierarchyTestCase {
+
+	static int topLevelBeforeAllInvocationCount = 0;
+	static int topLevelAfterAllInvocationCount = 0;
+	static int secondLevelBeforeAllInvocationCount = 0;
+	static int secondLevelAfterAllInvocationCount = 0;
+	static int thirdLevelBeforeAllInvocationCount = 0;
+	static int thirdLevelAfterAllInvocationCount = 0;
+
+	static int topLevelBeforeInvocationCount = 0;
+	static int topLevelAfterInvocationCount = 0;
+	static int secondLevelBeforeInvocationCount = 0;
+	static int secondLevelAfterInvocationCount = 0;
+	static int thirdLevelBeforeInvocationCount = 0;
+	static int thirdLevelAfterInvocationCount = 0;
+
+	static boolean topLevelTest1Invoked;
+	static boolean topLevelTest2Invoked;
+	static boolean secondLevelTest1Invoked;
+	static boolean secondLevelTest2Invoked;
+	static boolean thirdLevelTest1Invoked;
+	static boolean thirdLevelTest2Invoked;
+
+	@BeforeAll
+	void beforeAll() {
+		topLevelBeforeAllInvocationCount++;
+		System.out.println(getClass().getName() + " beforeAll called");
+	}
+
+	@AfterAll
+	void afterAll() {
+		topLevelAfterAllInvocationCount++;
+		System.out.println(getClass().getName() + " afterAll called");
+	}
+
+	@Before
+	void topLevelBefore() {
+		topLevelBeforeInvocationCount++;
+		System.out.println(getClass().getName() + " before called");
+	}
+
+	@After
+	void topLevelAfter() {
+		topLevelAfterInvocationCount++;
+		System.out.println(getClass().getName() + " after called");
+	}
+
+	@Test
+	void topLevelTest1() {
+		topLevelTest1Invoked = true;
+		System.out.println(getClass().getName() + " top level test1 called");
+	}
+
+	@Test
+	void topLevelTest2() {
+		topLevelTest2Invoked = true;
+		System.out.println(getClass().getName() + " top level test2 called");
+	}
+
+	@Context
+	class SecondLevelTestContext {
+
+		@BeforeAll
+		void beforeAll() {
+			secondLevelBeforeAllInvocationCount++;
+			System.out.println(getClass().getName() + " beforeAll called");
+		}
+
+		@AfterAll
+		void afterAll() {
+			secondLevelAfterAllInvocationCount++;
+			System.out.println(getClass().getName() + " afterAll called");
+		}
+
+		@Before
+		void secondLevelBefore() {
+			secondLevelBeforeInvocationCount++;
+			System.out.println(getClass().getName() + " before called");
+		}
+
+		@After
+		void secondLevelAfter() {
+			secondLevelAfterInvocationCount++;
+			System.out.println(getClass().getName() + " after called");
+		}
+
+		@Test
+		void secondLevelTest1() {
+			secondLevelTest1Invoked = true;
+			System.out.println(getClass().getName() + " second level test1 called");
+		}
+
+		@Test
+		void secondLevelTest2() {
+			secondLevelTest2Invoked = true;
+			System.out.println(getClass().getName() + " second level test2 called");
+		}
+
+		@Context
+		class ThirdLevelTestContext {
+
+			@BeforeAll
+			void beforeAll() {
+				thirdLevelBeforeAllInvocationCount++;
+				System.out.println(getClass().getName() + " beforeAll called");
+			}
+
+			@AfterAll
+			void afterAll() {
+				thirdLevelAfterAllInvocationCount++;
+				System.out.println(getClass().getName() + " afterAll called");
+			}
+
+			@Before
+			void secondLevelBefore() {
+				thirdLevelBeforeInvocationCount++;
+				System.out.println(getClass().getName() + " before called");
+			}
+
+			@After
+			void secondLevelAfter() {
+				thirdLevelAfterInvocationCount++;
+				System.out.println(getClass().getName() + " after called");
+			}
+
+			@Test
+			void thirdLevelTest1() {
+				thirdLevelTest1Invoked = true;
+				System.out.println(getClass().getName() + " second level test1 called");
+			}
+
+			@Test
+			void thirdLevelTest2() {
+				thirdLevelTest2Invoked = true;
+				System.out.println(getClass().getName() + " second level test2 called");
+			}
+		}
+	}
+}

--- a/sample-project/src/test/java/com/example/JUnit4SamplesSuite.java
+++ b/sample-project/src/test/java/com/example/JUnit4SamplesSuite.java
@@ -19,8 +19,11 @@ import org.junit.runner.RunWith;
 
 @RunWith(JUnit5.class)
 @Classes({ SucceedingTestCase.class })
-@UniqueIds({ "junit5:com.example.SampleTestCase#assertAllTest()",
-	"junit5:com.example.SampleTestCase#assertAllFailingTest()" })
+@UniqueIds({
+		"junit5:com.example.SampleTestCase#assertAllTest()",
+		"junit5:com.example.SampleTestCase#assertAllFailingTest()",
+		"junit5:com.example.SampleTestCase@AnInnerTestContext"
+})
 @Packages({ "com.example.subpackage" })
 //@Classes({ SampleTestCase.class, SucceedingTestCase.class, JUnit4TestCase.class })
 public class JUnit4SamplesSuite {

--- a/sample-project/src/test/java/com/example/SampleTestCase.java
+++ b/sample-project/src/test/java/com/example/SampleTestCase.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import org.junit.gen5.api.After;
 import org.junit.gen5.api.Before;
+import org.junit.gen5.api.Context;
 import org.junit.gen5.api.Name;
 import org.junit.gen5.api.Test;
 import org.opentestalliance.TestSkippedException;
@@ -115,8 +116,9 @@ class SampleTestCase {
 		// @formatter:on
 	}
 
-	// Currently ignored by junit5 engine
-	class InnerTestCase {
+	@Context
+	@Name("An inner test context")
+	class AnInnerTestContext {
 
 		@Test
 		void innerTest() {


### PR DESCRIPTION
One more pull request. I based this branch on Stefan's branch "contextsupport", fixed the resolver problems and merged it with current master.
The PR supports the resolution of nested contexts (inner classes with annotation @Context).
It does not yet execute them (i.e. ContextExecutionNode just skipps everything).