### PR TITLE
Testing package dependencies with Degraph

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,4 @@ junit4Version  = 4.12
 log4JVersion   = 2.4.1
 mockitoVersion = 1.10.19
 ota4jVersion   = 1.0.0-SNAPSHOT
+degraphVersion = 0.1.3

--- a/junit-tests/build.gradle
+++ b/junit-tests/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	testCompile("de.schauderhaft.degraph:degraph-check:${degraphVersion}")
 
 	testRuntime("org.apache.logging.log4j:log4j-core:${log4JVersion}")
+	testRuntime("org.apache.logging.log4j:log4j-jul:${log4JVersion}")
 }
 
 jacoco {

--- a/junit-tests/build.gradle
+++ b/junit-tests/build.gradle
@@ -21,9 +21,9 @@ dependencies {
 	testCompile("org.assertj:assertj-core:${assertJVersion}")
 	testCompile("junit:junit:${junit4Version}")
 	testCompile("org.mockito:mockito-core:${mockitoVersion}")
+	testCompile("de.schauderhaft.degraph:degraph-check:${degraphVersion}")
 
 	testRuntime("org.apache.logging.log4j:log4j-core:${log4JVersion}")
-	testRuntime("org.apache.logging.log4j:log4j-jul:${log4JVersion}")
 }
 
 jacoco {

--- a/junit-tests/src/test/java/org/junit/gen5/commons/util/org/junit/gen5/meta/DependencyTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/commons/util/org/junit/gen5/meta/DependencyTests.java
@@ -27,8 +27,9 @@ public class DependencyTests {
 
     @Test
     public void noCycles(){
+        // we can't use noJar(), because with gradle the dependencies of other modules are
+        // included as jar files in the path.
         Assert.assertThat(classpath()
-                .noJars()
                 .printTo("dependencies.graphml")
                 .including("org.junit.**")
                 .withSlicing("module", "org.junit.gen5.(*).**"),

--- a/junit-tests/src/test/java/org/junit/gen5/commons/util/org/junit/gen5/meta/DependencyTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/commons/util/org/junit/gen5/meta/DependencyTests.java
@@ -11,11 +11,10 @@
 package org.junit.gen5.commons.util.org.junit.gen5.meta;
 
 import static de.schauderhaft.degraph.check.JCheck.*;
+import static org.hamcrest.Matchers.is;
 
 import org.junit.Assert;
 import org.junit.Test;
-
-import static org.hamcrest.Matchers.is;
 
 /**
  * checks agains dependecy circles on package and module level.
@@ -25,14 +24,11 @@ import static org.hamcrest.Matchers.is;
  */
 public class DependencyTests {
 
-    @Test
-    public void noCycles(){
-        // we can't use noJar(), because with gradle the dependencies of other modules are
-        // included as jar files in the path.
-        Assert.assertThat(classpath()
-                .printTo("dependencies.graphml")
-                .including("org.junit.**")
-                .withSlicing("module", "org.junit.gen5.(*).**"),
-                is(violationFree()));
-    }
+	@Test
+	public void noCycles() {
+		// we can't use noJar(), because with gradle the dependencies of other modules are
+		// included as jar files in the path.
+		Assert.assertThat(classpath().printTo("dependencies.graphml").including("org.junit.**").withSlicing("module",
+			"org.junit.gen5.(*).**"), is(violationFree()));
+	}
 }

--- a/junit-tests/src/test/java/org/junit/gen5/commons/util/org/junit/gen5/meta/DependencyTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/commons/util/org/junit/gen5/meta/DependencyTests.java
@@ -17,13 +17,21 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 
+/**
+ * checks agains dependecy circles on package and module level.
+ *
+ * Modules in that sense are defined by the package name element after org.junit.gen5,
+ * so org.junit.gen5.engine.TestEngine belongs in the module engine.
+ */
 public class DependencyTests {
 
     @Test
     public void noCycles(){
         Assert.assertThat(classpath()
                 .noJars()
-                .printTo("dependencies.graphml"),
+                .printTo("dependencies.graphml")
+                .including("org.junit.**")
+                .withSlicing("module", "org.junit.gen5.(*).**"),
                 is(violationFree()));
     }
 }

--- a/junit-tests/src/test/java/org/junit/gen5/commons/util/org/junit/gen5/meta/DependencyTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/commons/util/org/junit/gen5/meta/DependencyTests.java
@@ -28,7 +28,10 @@ public class DependencyTests {
 	public void noCycles() {
 		// we can't use noJar(), because with gradle the dependencies of other modules are
 		// included as jar files in the path.
-		Assert.assertThat(classpath().printTo("dependencies.graphml").including("org.junit.**").withSlicing("module",
-			"org.junit.gen5.(*).**"), is(violationFree()));
+		Assert.assertThat(classpath() //
+		.printTo("dependencies.graphml") //
+		.including("org.junit.gen5.**") //
+		.withSlicing("module", "org.junit.gen5.(*).**"), //
+			is(violationFree()));
 	}
 }

--- a/junit-tests/src/test/java/org/junit/gen5/commons/util/org/junit/gen5/meta/DependencyTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/commons/util/org/junit/gen5/meta/DependencyTests.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.gen5.commons.util.org.junit.gen5.meta;
+
+import static de.schauderhaft.degraph.check.JCheck.*;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+
+public class DependencyTests {
+
+    @Test
+    public void noCycles(){
+        Assert.assertThat(classpath()
+                .noJars()
+                .printTo("dependencies.graphml"),
+                is(violationFree()));
+    }
+}

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestableTest.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestableTest.java
@@ -16,11 +16,21 @@ import java.math.BigDecimal;
 import org.junit.Assert;
 import org.junit.gen5.api.Test;
 import org.junit.gen5.engine.EngineDescriptor;
+import org.junit.gen5.engine.TestEngine;
 import org.junit.gen5.engine.junit5.JUnit5TestEngine;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class JUnit5TestableTest {
 
-	private final EngineDescriptor engineDescriptor = new EngineDescriptor(new JUnit5TestEngine());
+	private final EngineDescriptor engineDescriptor;
+
+	{
+		final TestEngine engine = mock(TestEngine.class);
+		when(engine.getId()).thenReturn("junit5");
+		engineDescriptor = new EngineDescriptor(engine);
+	}
 
 	@org.junit.Test
 	public void fromUniqueIdForTopLevelClass() {

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestableTest.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestableTest.java
@@ -28,7 +28,7 @@ public class JUnit5TestableTest {
 
 	{
 		final TestEngine engine = mock(TestEngine.class);
-		when(engine.getId()).thenReturn("junit5");
+		when(engine.getId()).thenReturn("ENGINE_ID");
 		engineDescriptor = new EngineDescriptor(engine);
 	}
 
@@ -36,8 +36,8 @@ public class JUnit5TestableTest {
 	public void fromUniqueIdForTopLevelClass() {
 
 		JUnit5Class testable = (JUnit5Class) JUnit5Testable.fromUniqueId(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.ATestClass", engineDescriptor.getUniqueId());
-		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.descriptor.ATestClass", testable.getUniqueId());
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.ATestClass", engineDescriptor.getUniqueId());
+		Assert.assertEquals("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.ATestClass", testable.getUniqueId());
 		Assert.assertSame(ATestClass.class, testable.getJavaClass());
 	}
 
@@ -45,9 +45,9 @@ public class JUnit5TestableTest {
 	public void fromUniqueIdForNestedClass() {
 
 		JUnit5Class testable = (JUnit5Class) JUnit5Testable.fromUniqueId(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.ATestClass$AnInnerTestClass",
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.ATestClass$AnInnerTestClass",
 			engineDescriptor.getUniqueId());
-		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.descriptor.ATestClass$AnInnerTestClass",
+		Assert.assertEquals("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.ATestClass$AnInnerTestClass",
 			testable.getUniqueId());
 		Assert.assertSame(ATestClass.AnInnerTestClass.class, testable.getJavaClass());
 	}
@@ -56,10 +56,10 @@ public class JUnit5TestableTest {
 	public void fromUniqueIdForDoubleNestedClass() {
 
 		JUnit5Class testable = (JUnit5Class) JUnit5Testable.fromUniqueId(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.ATestClass$AnInnerTestClass$InnerInnerTestClass",
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.ATestClass$AnInnerTestClass$InnerInnerTestClass",
 			engineDescriptor.getUniqueId());
 		Assert.assertEquals(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.ATestClass$AnInnerTestClass$InnerInnerTestClass",
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.ATestClass$AnInnerTestClass$InnerInnerTestClass",
 			testable.getUniqueId());
 		Assert.assertSame(ATestClass.AnInnerTestClass.InnerInnerTestClass.class, testable.getJavaClass());
 	}
@@ -68,8 +68,8 @@ public class JUnit5TestableTest {
 	public void fromUniqueIdForMethod() throws NoSuchMethodException {
 
 		JUnit5Method testable = (JUnit5Method) JUnit5Testable.fromUniqueId(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.ATestClass#test1()", engineDescriptor.getUniqueId());
-		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.descriptor.ATestClass#test1()",
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.ATestClass#test1()", engineDescriptor.getUniqueId());
+		Assert.assertEquals("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.ATestClass#test1()",
 			testable.getUniqueId());
 		Method testMethod = ATestClass.class.getDeclaredMethod("test1");
 		Assert.assertEquals(testMethod, testable.getJavaMethod());
@@ -79,10 +79,10 @@ public class JUnit5TestableTest {
 	public void fromUniqueIdForMethodWithParameters() throws NoSuchMethodException {
 
 		JUnit5Method testable = (JUnit5Method) JUnit5Testable.fromUniqueId(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.BTestClass#test4(java.lang.String, java.math.BigDecimal)",
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.BTestClass#test4(java.lang.String, java.math.BigDecimal)",
 			engineDescriptor.getUniqueId());
 		Assert.assertEquals(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.BTestClass#test4(java.lang.String, java.math.BigDecimal)",
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.BTestClass#test4(java.lang.String, java.math.BigDecimal)",
 			testable.getUniqueId());
 		Method testMethod = BTestClass.class.getDeclaredMethod("test4", String.class, BigDecimal.class);
 		Assert.assertEquals(testMethod, testable.getJavaMethod());
@@ -92,9 +92,9 @@ public class JUnit5TestableTest {
 	public void fromUniqueIdForMethodInNestedClass() throws NoSuchMethodException {
 
 		JUnit5Method testable = (JUnit5Method) JUnit5Testable.fromUniqueId(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.ATestClass$AnInnerTestClass#test2()",
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.ATestClass$AnInnerTestClass#test2()",
 			engineDescriptor.getUniqueId());
-		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.descriptor.ATestClass$AnInnerTestClass#test2()",
+		Assert.assertEquals("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.ATestClass$AnInnerTestClass#test2()",
 			testable.getUniqueId());
 		Method testMethod = ATestClass.AnInnerTestClass.class.getDeclaredMethod("test2");
 		Assert.assertEquals(testMethod, testable.getJavaMethod());
@@ -103,7 +103,7 @@ public class JUnit5TestableTest {
 	@org.junit.Test
 	public void fromClass() throws NoSuchMethodException {
 		JUnit5Class testable = (JUnit5Class) JUnit5Testable.fromClass(ATestClass.class, engineDescriptor.getUniqueId());
-		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.descriptor.ATestClass", testable.getUniqueId());
+		Assert.assertEquals("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.ATestClass", testable.getUniqueId());
 		Assert.assertSame(ATestClass.class, testable.getJavaClass());
 	}
 
@@ -111,7 +111,7 @@ public class JUnit5TestableTest {
 	public void nestedClassFromClass() throws NoSuchMethodException {
 		JUnit5Class testable = (JUnit5Class) JUnit5Testable.fromClass(ATestClass.AnInnerTestClass.class,
 			engineDescriptor.getUniqueId());
-		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.descriptor.ATestClass$AnInnerTestClass",
+		Assert.assertEquals("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.ATestClass$AnInnerTestClass",
 			testable.getUniqueId());
 		Assert.assertSame(ATestClass.AnInnerTestClass.class, testable.getJavaClass());
 	}
@@ -121,7 +121,7 @@ public class JUnit5TestableTest {
 		Method testMethod = ATestClass.class.getDeclaredMethod("test1");
 		JUnit5Method testable = (JUnit5Method) JUnit5Testable.fromMethod(testMethod, ATestClass.class,
 			engineDescriptor.getUniqueId());
-		Assert.assertEquals("junit5:org.junit.gen5.engine.junit5.descriptor.ATestClass#test1()",
+		Assert.assertEquals("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.ATestClass#test1()",
 			testable.getUniqueId());
 		Assert.assertSame(testMethod, testable.getJavaMethod());
 		Assert.assertSame(ATestClass.class, testable.getContainerClass());
@@ -133,7 +133,7 @@ public class JUnit5TestableTest {
 		JUnit5Method testable = (JUnit5Method) JUnit5Testable.fromMethod(testMethod, BTestClass.class,
 			engineDescriptor.getUniqueId());
 		Assert.assertEquals(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.BTestClass#test4(java.lang.String, java.math.BigDecimal)",
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.BTestClass#test4(java.lang.String, java.math.BigDecimal)",
 			testable.getUniqueId());
 		Assert.assertSame(testMethod, testable.getJavaMethod());
 	}

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestableTest.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestableTest.java
@@ -10,6 +10,9 @@
 
 package org.junit.gen5.engine.junit5.descriptor;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 
@@ -18,9 +21,6 @@ import org.junit.gen5.api.Test;
 import org.junit.gen5.engine.EngineDescriptor;
 import org.junit.gen5.engine.TestEngine;
 import org.junit.gen5.engine.junit5.JUnit5TestEngine;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class JUnit5TestableTest {
 

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolverTest.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolverTest.java
@@ -11,6 +11,8 @@
 package org.junit.gen5.engine.junit5.descriptor;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,13 +23,22 @@ import org.junit.gen5.engine.ClassSpecification;
 import org.junit.gen5.engine.MethodSpecification;
 import org.junit.gen5.engine.PackageSpecification;
 import org.junit.gen5.engine.TestDescriptor;
+import org.junit.gen5.engine.TestEngine;
 import org.junit.gen5.engine.UniqueIdSpecification;
 import org.junit.gen5.engine.junit5.JUnit5TestEngine;
 
 public class SpecificationResolverTest {
 
-	private final JUnit5EngineDescriptor engineDescriptor = new JUnit5EngineDescriptor(new JUnit5TestEngine());
-	private SpecificationResolver resolver = new SpecificationResolver(engineDescriptor);
+	private final JUnit5EngineDescriptor engineDescriptor;
+	private SpecificationResolver resolver;
+
+	{
+		final TestEngine engine = mock(TestEngine.class);
+		when(engine.getId()).thenReturn("junit5");
+		engineDescriptor = new JUnit5EngineDescriptor(engine);
+		resolver = new SpecificationResolver(engineDescriptor);
+	}
+
 
 	@org.junit.Test
 	public void testSingleClassResolution() {

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolverTest.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolverTest.java
@@ -34,7 +34,7 @@ public class SpecificationResolverTest {
 
 	{
 		final TestEngine engine = mock(TestEngine.class);
-		when(engine.getId()).thenReturn("junit5");
+		when(engine.getId()).thenReturn("ENGINE_ID");
 		engineDescriptor = new JUnit5EngineDescriptor(engine);
 		resolver = new SpecificationResolver(engineDescriptor);
 	}
@@ -48,9 +48,9 @@ public class SpecificationResolverTest {
 
 		assertEquals(3, engineDescriptor.allDescendants().size());
 		List<String> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test2()"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test2()"));
 	}
 
 	@org.junit.Test
@@ -64,12 +64,12 @@ public class SpecificationResolverTest {
 		assertEquals(6, engineDescriptor.allDescendants().size());
 		List<String> uniqueIds = engineDescriptor.allDescendants().stream().map(d -> d.getUniqueId()).collect(
 			Collectors.toList());
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test2()"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.YourTestClass"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.YourTestClass#test3()"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.YourTestClass#test4()"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test2()"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.YourTestClass"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.YourTestClass#test3()"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.YourTestClass#test4()"));
 	}
 
 	@org.junit.Test
@@ -81,11 +81,11 @@ public class SpecificationResolverTest {
 		assertEquals(3, engineDescriptor.allDescendants().size());
 		List<String> uniqueIds = engineDescriptor.allDescendants().stream().map(d -> d.getUniqueId()).collect(
 			Collectors.toList());
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass"));
 		assertTrue(uniqueIds.contains(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test5()"));
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test5()"));
 		assertTrue(uniqueIds.contains(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test6()"));
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test6()"));
 	}
 
 	@org.junit.Test
@@ -98,8 +98,8 @@ public class SpecificationResolverTest {
 
 		assertEquals(2, engineDescriptor.allDescendants().size());
 		List<String> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()"));
 	}
 
 	@org.junit.Test
@@ -111,8 +111,8 @@ public class SpecificationResolverTest {
 
 		assertEquals(2, engineDescriptor.allDescendants().size());
 		List<String> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.HerTestClass"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.HerTestClass#test1()"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.HerTestClass"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.HerTestClass#test1()"));
 	}
 
 	@org.junit.Test(expected = IllegalArgumentException.class)
@@ -126,50 +126,50 @@ public class SpecificationResolverTest {
 	@org.junit.Test
 	public void testClassResolutionByUniqueId() {
 		UniqueIdSpecification specification = new UniqueIdSpecification(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass");
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass");
 
 		resolver.resolveElement(specification);
 
 		assertEquals(3, engineDescriptor.allDescendants().size());
 		List<String> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test2()"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test2()"));
 	}
 
 	@org.junit.Test
 	public void testInnerClassResolutionByUniqueId() {
 		UniqueIdSpecification specification = new UniqueIdSpecification(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass");
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass");
 
 		resolver.resolveElement(specification);
 
 		assertEquals(3, engineDescriptor.allDescendants().size());
 		List<String> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass"));
 		assertTrue(uniqueIds.contains(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test5()"));
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test5()"));
 		assertTrue(uniqueIds.contains(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test6()"));
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test6()"));
 	}
 
 	@org.junit.Test
 	public void testMethodOfInnerClassByUniqueId() {
 		UniqueIdSpecification specification = new UniqueIdSpecification(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test5()");
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test5()");
 
 		resolver.resolveElement(specification);
 
 		assertEquals(2, engineDescriptor.allDescendants().size());
 		List<String> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass"));
 		assertTrue(uniqueIds.contains(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test5()"));
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test5()"));
 	}
 
 	@org.junit.Test(expected = IllegalArgumentException.class)
 	public void testNonResolvableUniqueId() {
-		UniqueIdSpecification specification1 = new UniqueIdSpecification("junit5:poops-machine");
+		UniqueIdSpecification specification1 = new UniqueIdSpecification("ENGINE_ID:poops-machine");
 
 		resolver.resolveElement(specification1);
 	}
@@ -177,27 +177,27 @@ public class SpecificationResolverTest {
 	@org.junit.Test(expected = IllegalArgumentException.class)
 	public void testUniqueIdOfNotTestMethod() {
 		UniqueIdSpecification specification1 = new UniqueIdSpecification(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#notATest()");
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass#notATest()");
 		resolver.resolveElement(specification1);
 	}
 
 	@org.junit.Test
 	public void testMethodResolutionByUniqueId() {
 		UniqueIdSpecification specification = new UniqueIdSpecification(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()");
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()");
 
 		resolver.resolveElement(specification);
 
 		assertEquals(2, engineDescriptor.allDescendants().size());
 		List<String> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()"));
 	}
 
 	@org.junit.Test
 	public void testMethodResolutionByUniqueIdFromInheritedClass() {
 		UniqueIdSpecification specification = new UniqueIdSpecification(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.HerTestClass#test1()");
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.HerTestClass#test1()");
 
 		resolver.resolveElement(specification);
 
@@ -205,14 +205,14 @@ public class SpecificationResolverTest {
 		List<String> uniqueIds = uniqueIds();
 
 		// System.out.println(uniqueIds);
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.HerTestClass"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.HerTestClass#test1()"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.HerTestClass"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.HerTestClass#test1()"));
 	}
 
 	@org.junit.Test
 	public void testMethodResolutionByUniqueIdWithParams() {
 		UniqueIdSpecification specification = new UniqueIdSpecification(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.HerTestClass#test7(java.lang.String)");
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.HerTestClass#test7(java.lang.String)");
 
 		resolver.resolveElement(specification);
 
@@ -220,15 +220,15 @@ public class SpecificationResolverTest {
 		List<String> uniqueIds = uniqueIds();
 
 		// System.out.println(uniqueIds);
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.HerTestClass"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.HerTestClass"));
 		assertTrue(
-			uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.HerTestClass#test7(java.lang.String)"));
+			uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.HerTestClass#test7(java.lang.String)"));
 	}
 
 	@org.junit.Test(expected = IllegalArgumentException.class)
 	public void testMethodResolutionByUniqueIdWithWrongParams() {
 		UniqueIdSpecification specification = new UniqueIdSpecification(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.HerTestClass#test7(java.math.BigDecimal)");
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.HerTestClass#test7(java.math.BigDecimal)");
 
 		resolver.resolveElement(specification);
 	}
@@ -236,9 +236,9 @@ public class SpecificationResolverTest {
 	@org.junit.Test
 	public void testTwoMethodResolutionsByUniqueId() {
 		UniqueIdSpecification specification1 = new UniqueIdSpecification(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()");
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()");
 		UniqueIdSpecification specification2 = new UniqueIdSpecification(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test2()");
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test2()");
 
 		resolver.resolveElement(specification1);
 		resolver.resolveElement(specification2);
@@ -246,14 +246,14 @@ public class SpecificationResolverTest {
 
 		assertEquals(3, engineDescriptor.allDescendants().size());
 		List<String> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test2()"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test2()"));
 
 		TestDescriptor classFromMethod1 = descriptorByUniqueId(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()").getParent().get();
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test1()").getParent().get();
 		TestDescriptor classFromMethod2 = descriptorByUniqueId(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test2()").getParent().get();
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.MyTestClass#test2()").getParent().get();
 
 		assertEquals(classFromMethod1, classFromMethod2);
 		assertSame(classFromMethod1, classFromMethod2);
@@ -267,12 +267,12 @@ public class SpecificationResolverTest {
 
 		assertEquals(4, engineDescriptor.allDescendants().size());
 		List<String> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.subpackage.Class1WithTestCases"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.subpackage.Class1WithTestCases"));
 		assertTrue(uniqueIds.contains(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.subpackage.Class1WithTestCases#test1()"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.subpackage.Class2WithTestCases"));
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.subpackage.Class1WithTestCases#test1()"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.subpackage.Class2WithTestCases"));
 		assertTrue(uniqueIds.contains(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.subpackage.Class2WithTestCases#test2()"));
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.subpackage.Class2WithTestCases#test2()"));
 	}
 
 	@org.junit.Test
@@ -287,15 +287,15 @@ public class SpecificationResolverTest {
 			Collectors.toList());
 		assertEquals(6, uniqueIds.size());
 
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting#testA()"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting#testA()"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
 		assertTrue(uniqueIds.contains(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest#testB()"));
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest#testB()"));
 		assertTrue(uniqueIds.contains(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest"));
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest"));
 		assertTrue(uniqueIds.contains(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest#testC()"));
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest#testC()"));
 	}
 
 	@org.junit.Test
@@ -308,20 +308,20 @@ public class SpecificationResolverTest {
 			Collectors.toList());
 		assertEquals(5, uniqueIds.size());
 
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
 		assertTrue(uniqueIds.contains(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest#testB()"));
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest#testB()"));
 		assertTrue(uniqueIds.contains(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest"));
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest"));
 		assertTrue(uniqueIds.contains(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest#testC()"));
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest#testC()"));
 	}
 
 	@org.junit.Test
 	public void testNestedTestResolutionFromUniqueId() {
 		UniqueIdSpecification specification = new UniqueIdSpecification(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest");
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest");
 
 		resolver.resolveElement(specification);
 
@@ -329,12 +329,12 @@ public class SpecificationResolverTest {
 			Collectors.toList());
 		assertEquals(4, uniqueIds.size());
 
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
 		assertTrue(uniqueIds.contains(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest"));
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest"));
 		assertTrue(uniqueIds.contains(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest#testC()"));
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest#testC()"));
 	}
 
 	@org.junit.Test
@@ -348,18 +348,18 @@ public class SpecificationResolverTest {
 			Collectors.toList());
 		assertEquals(4, uniqueIds.size());
 
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
 		assertTrue(uniqueIds.contains(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest"));
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest"));
 		assertTrue(uniqueIds.contains(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest#testC()"));
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest#testC()"));
 	}
 
 	@org.junit.Test
 	public void testNestedTestResolutionFromUniqueIdToMethod() {
 		UniqueIdSpecification specification = new UniqueIdSpecification(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest#testB()");
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest#testB()");
 
 		resolver.resolveElement(specification);
 
@@ -367,10 +367,10 @@ public class SpecificationResolverTest {
 			Collectors.toList());
 		assertEquals(3, uniqueIds.size());
 
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting"));
-		assertTrue(uniqueIds.contains("junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting"));
+		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
 		assertTrue(uniqueIds.contains(
-			"junit5:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest#testB()"));
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest#testB()"));
 	}
 
 	private TestDescriptor descriptorByUniqueId(String id) {

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolverTest.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/descriptor/SpecificationResolverTest.java
@@ -39,7 +39,6 @@ public class SpecificationResolverTest {
 		resolver = new SpecificationResolver(engineDescriptor);
 	}
 
-
 	@org.junit.Test
 	public void testSingleClassResolution() {
 		ClassSpecification specification = new ClassSpecification(MyTestClass.class);
@@ -81,7 +80,8 @@ public class SpecificationResolverTest {
 		assertEquals(3, engineDescriptor.allDescendants().size());
 		List<String> uniqueIds = engineDescriptor.allDescendants().stream().map(d -> d.getUniqueId()).collect(
 			Collectors.toList());
-		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass"));
+		assertTrue(
+			uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass"));
 		assertTrue(uniqueIds.contains(
 			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test5()"));
 		assertTrue(uniqueIds.contains(
@@ -146,7 +146,8 @@ public class SpecificationResolverTest {
 
 		assertEquals(3, engineDescriptor.allDescendants().size());
 		List<String> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass"));
+		assertTrue(
+			uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass"));
 		assertTrue(uniqueIds.contains(
 			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test5()"));
 		assertTrue(uniqueIds.contains(
@@ -162,7 +163,8 @@ public class SpecificationResolverTest {
 
 		assertEquals(2, engineDescriptor.allDescendants().size());
 		List<String> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass"));
+		assertTrue(
+			uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass"));
 		assertTrue(uniqueIds.contains(
 			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.OtherTestClass$NestedTestClass#test5()"));
 	}
@@ -221,8 +223,8 @@ public class SpecificationResolverTest {
 
 		// System.out.println(uniqueIds);
 		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.HerTestClass"));
-		assertTrue(
-			uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.HerTestClass#test7(java.lang.String)"));
+		assertTrue(uniqueIds.contains(
+			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.HerTestClass#test7(java.lang.String)"));
 	}
 
 	@org.junit.Test(expected = IllegalArgumentException.class)
@@ -267,10 +269,12 @@ public class SpecificationResolverTest {
 
 		assertEquals(4, engineDescriptor.allDescendants().size());
 		List<String> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.subpackage.Class1WithTestCases"));
+		assertTrue(
+			uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.subpackage.Class1WithTestCases"));
 		assertTrue(uniqueIds.contains(
 			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.subpackage.Class1WithTestCases#test1()"));
-		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.subpackage.Class2WithTestCases"));
+		assertTrue(
+			uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.subpackage.Class2WithTestCases"));
 		assertTrue(uniqueIds.contains(
 			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.subpackage.Class2WithTestCases#test2()"));
 	}
@@ -289,7 +293,8 @@ public class SpecificationResolverTest {
 
 		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting"));
 		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting#testA()"));
-		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
+		assertTrue(
+			uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
 		assertTrue(uniqueIds.contains(
 			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest#testB()"));
 		assertTrue(uniqueIds.contains(
@@ -309,7 +314,8 @@ public class SpecificationResolverTest {
 		assertEquals(5, uniqueIds.size());
 
 		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting"));
-		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
+		assertTrue(
+			uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
 		assertTrue(uniqueIds.contains(
 			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest#testB()"));
 		assertTrue(uniqueIds.contains(
@@ -330,7 +336,8 @@ public class SpecificationResolverTest {
 		assertEquals(4, uniqueIds.size());
 
 		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting"));
-		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
+		assertTrue(
+			uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
 		assertTrue(uniqueIds.contains(
 			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest"));
 		assertTrue(uniqueIds.contains(
@@ -349,7 +356,8 @@ public class SpecificationResolverTest {
 		assertEquals(4, uniqueIds.size());
 
 		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting"));
-		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
+		assertTrue(
+			uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
 		assertTrue(uniqueIds.contains(
 			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest@DoubleNestedTest"));
 		assertTrue(uniqueIds.contains(
@@ -368,7 +376,8 @@ public class SpecificationResolverTest {
 		assertEquals(3, uniqueIds.size());
 
 		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting"));
-		assertTrue(uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
+		assertTrue(
+			uniqueIds.contains("ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest"));
 		assertTrue(uniqueIds.contains(
 			"ENGINE_ID:org.junit.gen5.engine.junit5.descriptor.TestCaseWithNesting@NestedTest#testB()"));
 	}

--- a/junit-tests/src/test/java/org/junit/gen5/meta/DependencyTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/meta/DependencyTests.java
@@ -11,11 +11,11 @@
 package org.junit.gen5.meta;
 
 import static de.schauderhaft.degraph.check.JCheck.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import de.schauderhaft.degraph.configuration.NamedPattern;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -30,7 +30,7 @@ public class DependencyTests {
 	public void noCycles() {
 		// we can't use noJar(), because with gradle the dependencies of other modules are
 		// included as jar files in the path.
-		Assert.assertThat(classpath() //
+		assertThat(classpath() //
 		.printTo("dependencies.graphml") //
 		.including("org.junit.gen5.**") //
 		.withSlicing("module", new NamedPattern("org.junit.gen5.engine.junit4.**", "junit4-engine"),

--- a/junit-tests/src/test/java/org/junit/gen5/meta/DependencyTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/meta/DependencyTests.java
@@ -8,7 +8,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  */
 
-package org.junit.gen5.commons.util.org.junit.gen5.meta;
+package org.junit.gen5.meta;
 
 import static de.schauderhaft.degraph.check.JCheck.*;
 import static org.hamcrest.Matchers.is;

--- a/junit-tests/src/test/java/org/junit/gen5/meta/DependencyTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/meta/DependencyTests.java
@@ -13,6 +13,8 @@ package org.junit.gen5.meta;
 import static de.schauderhaft.degraph.check.JCheck.*;
 import static org.hamcrest.Matchers.is;
 
+import de.schauderhaft.degraph.configuration.NamedPattern;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -31,7 +33,9 @@ public class DependencyTests {
 		Assert.assertThat(classpath() //
 		.printTo("dependencies.graphml") //
 		.including("org.junit.gen5.**") //
-		.withSlicing("module", "org.junit.gen5.(*).**"), //
+		.withSlicing("module", new NamedPattern("org.junit.gen5.engine.junit4.**", "junit4-engine"),
+			new NamedPattern("org.junit.gen5.engine.junit5.**", "junit5-engine"),
+			new NamedPattern("org.junit.gen5.engine.**", "engine-api"), "org.junit.gen5.(*).**"), //
 			is(violationFree()));
 	}
 }


### PR DESCRIPTION
Adds a test that tests for dependency cycles on package an module level.

Modules in this sense are all classes that start with the same package: org.junit.gen5.x

In order to make the test pass I had to break to dependencies from test to the JUnit5TestEngine. Since the engine wasn't really part of the test, I replaced it with a mock.

I agree to https://github.com/junit-team/junit-lambda/blob/master/CONTRIBUTING.md