### PR TITLE
Checkstyle for Javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ subprojects {
 	apply plugin: 'maven'
 	apply plugin: 'signing'
 	apply plugin: 'com.diffplug.gradle.spotless'
+	apply plugin: 'checkstyle'
 
 	repositories {
 		mavenCentral()
@@ -34,7 +35,9 @@ subprojects {
 		options.compilerArgs += '-parameters'
 	}
 
-	dependencies {
+	checkstyle {
+		toolVersion = 6.11
+		configFile = rootProject.file('src/checkstyle/checkstyle.xml')
 	}
 
 	eclipse {

--- a/junit-commons/src/main/java/org/junit/gen5/commons/util/AnnotationUtils.java
+++ b/junit-commons/src/main/java/org/junit/gen5/commons/util/AnnotationUtils.java
@@ -152,6 +152,7 @@ public final class AnnotationUtils {
 	 * {@code annotationType} that are either <em>present</em>,
 	 * <em>indirectly present</em>, or <em>meta-present</em> on the supplied
 	 * {@link AnnotatedElement}.
+	 *
 	 * <p>This method extends the functionality of
 	 * {@link java.lang.reflect.AnnotatedElement#getAnnotationsByType(Class)}
 	 * with additional support for meta-annotations.

--- a/junit-commons/src/main/java/org/junit/gen5/commons/util/ReflectionUtils.java
+++ b/junit-commons/src/main/java/org/junit/gen5/commons/util/ReflectionUtils.java
@@ -89,7 +89,7 @@ public final class ReflectionUtils {
 		Preconditions.notNull(clazz, "class must not be null");
 
 		try {
-			Class<?>[] parameterTypes = Arrays.stream(args).map(Object::getClass).toArray(Class<?>[]::new);
+			Class<?>[] parameterTypes = Arrays.stream(args).map(Object::getClass).toArray(Class[]::new);
 			Constructor<T> constructor = clazz.getDeclaredConstructor(parameterTypes);
 			makeAccessible(constructor);
 			return constructor.newInstance(args);

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/TestIdentifier.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/TestIdentifier.java
@@ -22,9 +22,8 @@ import org.junit.gen5.engine.TestTag;
 /**
  * Immutable data transfer object that describes a test or a test container.
  *
- * @see TestPlan
- *
  * @since 5.0
+ * @see TestPlan
  */
 public final class TestIdentifier {
 

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/AfterAllExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/AfterAllExtensionPoint.java
@@ -13,10 +13,10 @@ package org.junit.gen5.api.extension;
 /**
  * {@code AfterAllCallbacks} defines the API for {@link TestExtension TestExtensions} that wish to provide additional
  * behavior to tests after all test methods have been invoked.
- * <p>
- * Concrete implementations often implement {@link BeforeAllExtensionPoint} as well.
- * <p>
- * Implementations must provide a no-args constructor.
+ *
+ * <p>Concrete implementations often implement {@link BeforeAllExtensionPoint} as well.
+ *
+ * <p>Implementations must provide a no-args constructor.
  *
  * @since 5.0
  * @see org.junit.gen5.api.AfterAll

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeAllExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeAllExtensionPoint.java
@@ -13,10 +13,10 @@ package org.junit.gen5.api.extension;
 /**
  * {@code BeforeAllCallbacks} defines the API for {@link TestExtension TestExtensions} that wish to provide additional
  * behavior to tests before all test methods have been invoked.
- * <p>
- * Concrete implementations often implement {@link AfterAllExtensionPoint} as well.
- * <p>
- * Implementations must provide a no-args constructor.
+ *
+ * <p>Concrete implementations often implement {@link AfterAllExtensionPoint} as well.
+ *
+ * <p>Implementations must provide a no-args constructor.
  *
  * @since 5.0
  * @see org.junit.gen5.api.BeforeAll

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeEachExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeEachExtensionPoint.java
@@ -13,10 +13,10 @@ package org.junit.gen5.api.extension;
 /**
  * {@code BeforeEachCallbacks} defines the API for {@link ExtensionPoint} that wish to provide additional
  * behavior to tests before each test method has been invoked.
- * <p>
- * Concrete implementations often implement {@link AfterEachExtensionPoint} as well.
- * <p>
- * Implementations must provide a no-args constructor.
+ *
+ * <p>Concrete implementations often implement {@link AfterEachExtensionPoint} as well.
+ *
+ * <p>Implementations must provide a no-args constructor.
  *
  * @since 5.0
  * @see org.junit.gen5.api.BeforeEach

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionRegistrar.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionRegistrar.java
@@ -13,8 +13,8 @@ package org.junit.gen5.api.extension;
 /**
  * Interface to be implemented by more complex {@linkplain TestExtension}s that need to register
  * {@linkplain ExtensionPoint} instances with other Position than DEFAULT.
- * <p>
- * {@code ExtensionPointRegistrar} can be registered via {@link ExtendWith @ExtendWith}.
+ *
+ * <p>{@code ExtensionPointRegistrar} can be registered via {@link ExtendWith @ExtendWith}.
  *
  * @since 5.0
  */

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ShouldContainerBeExecutedCondition.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ShouldContainerBeExecutedCondition.java
@@ -13,11 +13,11 @@ package org.junit.gen5.api.extension;
 /**
  * {@code ShouldContainerBeExecutedCondition} defines the {@link ExtensionPoint} API for programmatic,
  * <em>conditional container execution</em>.
- * <p>
- * A {@code ShouldContainerBeExecutedCondition} is evaluated with {@linkplain #shouldContainerBeExecuted evaluated} to
+ *
+ * <p>A {@code ShouldContainerBeExecutedCondition} is evaluated with {@linkplain #shouldContainerBeExecuted evaluated} to
  * determine if a all tests in a given container should be executed based on the supplied {@link TestExtensionContext}.
- * <p>
- * Implementations must provide a no-args constructor.
+ *
+ * <p>Implementations must provide a no-args constructor.
  *
  * @since 5.0
  * @see org.junit.gen5.api.Disabled
@@ -27,8 +27,8 @@ public interface ShouldContainerBeExecutedCondition extends ExtensionPoint {
 
 	/**
 	 * Evaluate this condition for the supplied {@link ContainerExtensionContext}.
-	 * <p>
-	 * An {@linkplain ConditionEvaluationResult#enabled enabled} result indicates that the test should be executed;
+	 *
+	 * <p>An {@linkplain ConditionEvaluationResult#enabled enabled} result indicates that the test should be executed;
 	 * whereas, a {@linkplain ConditionEvaluationResult#disabled disabled} result indicates that the test should not be
 	 * executed.
 	 *

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/ClassTestDescriptor.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/ClassTestDescriptor.java
@@ -47,8 +47,8 @@ import org.junit.gen5.engine.junit5.execution.ThrowingConsumer;
 
 /**
  * {@link TestDescriptor} for tests based on Java classes.
- * <p>
- * The pattern of the {@link #getUniqueId unique ID} takes the form of
+ *
+ * <p>The pattern of the {@link #getUniqueId unique ID} takes the form of
  * <code>{parent unique id}:{fully qualified class name}</code>.
  *
  * @since 5.0

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/MethodInvoker.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/MethodInvoker.java
@@ -50,7 +50,6 @@ public class MethodInvoker {
 	/**
 	 * Resolve the array of parameters for the configured method.
 	 *
-	 * @param methodContext
 	 * @return the array of Objects to be used as parameters in the method
 	 * invocation; never {@code null} though potentially empty
 	 */

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/RegisteredExtensionPoint.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/RegisteredExtensionPoint.java
@@ -18,8 +18,8 @@ import org.junit.gen5.commons.util.ToStringBuilder;
  * Represents an {@linkplain ExtensionPoint extension} registered in a
  * {@link TestExtensionRegistry}.
  *
- * @since 5.0
  * @param <T> the concrete subtype of {@link ExtensionPoint} to be registered
+ * @since 5.0
  */
 public class RegisteredExtensionPoint<T extends ExtensionPoint> {
 

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/TestExtensionRegistry.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/TestExtensionRegistry.java
@@ -45,7 +45,7 @@ public class TestExtensionRegistry {
 	/**
 	 * Used to create and populate a new registry from a list of extensions and a parent.
 	 *
-	 * @param parentRegistry
+	 * @param parentRegistry The parent registry to be used.
 	 * @param extensionClasses The extensions to be registered in the new registry
 	 * @return a new TestExtensionRegistry
 	 */
@@ -118,8 +118,8 @@ public class TestExtensionRegistry {
 	/**
 	 * Apply all extension points for a given type in the right order.
 	 *
-	 * @param <T> The exact {@linkplain ExtensionPoint} for which to find all extensions
-	 * @param extensionClass
+	 * @param <T> The exact {@link ExtensionPoint} for which to find all extensions
+	 * @param extensionClass The {@link ExtensionPoint} class
 	 * @param order The order in which to apply the extension points after sorting. FORWARD or BACKWARD.
 	 * @param extensionPointApplier The code to execute for each extension point
 	 */

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+	<property name="severity" value="warning" />
+	<module name="TreeWalker">
+		<module name="SuppressWarningsHolder" />
+
+		<module name="JavadocMethod">
+			<property name="allowMissingJavadoc" value="true" />
+			<property name="allowMissingParamTags" value="true" />
+			<property name="allowMissingReturnTag" value="true" />
+			<property name="allowMissingThrowsTags" value="true" />
+			<property name="validateThrows" value="true" />
+		</module>
+		<module name="JavadocParagraph" />
+		<module name="AtclauseOrder">
+			<property name="tagOrder" value="@author, @param, @return, @throws, @exception, @since, @see" />
+		</module>
+		<module name="NonEmptyAtclauseDescription" />
+
+	</module>
+	<module name="SuppressWarningsFilter" />
+</module>

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
-	<property name="severity" value="warning" />
+	<property name="severity" value="error" />
 	<module name="TreeWalker">
 		<module name="SuppressWarningsHolder" />
 


### PR DESCRIPTION
This pull request is related to #67 and adds Checkstyle to the Gradle build to check the following basics for Javadoc:

- Paragraphs are separated by blank lines and prefixes with `<p>` immediately before the first word of the paragraph (`JavadocParagraph`).
- Exceptions documented using `@throws` on methods must be present on their signature (`JavadocMethod`).
- The order of "tags"/"at clauses" must be `@author`, `@param`, `@return`, `@throws`, `@exception`, `@since`, `@see` (`AtclauseOrder`).
- All "tags"/"at clauses" must have a description. (`NonEmptyAtclauseDescription`).