### PR TITLE
ReflectionUtils.invoke now throws Throwable.

### DIFF
--- a/junit-commons/src/main/java/org/junit/gen5/commons/util/ReflectionUtils.java
+++ b/junit-commons/src/main/java/org/junit/gen5/commons/util/ReflectionUtils.java
@@ -85,7 +85,7 @@ public final class ReflectionUtils {
 		return Modifier.isStatic(member.getModifiers());
 	}
 
-	public static <T> T newInstance(Class<T> clazz, Object... args) {
+	public static <T> T newInstance(Class<T> clazz, Object... args) throws Throwable {
 		Preconditions.notNull(clazz, "class must not be null");
 
 		try {
@@ -113,7 +113,7 @@ public final class ReflectionUtils {
 	 * @return the value returned by the method invocation or {@code null}
 	 * if the return type is {@code void}
 	 */
-	public static Object invokeMethod(Method method, Object target, Object... args) {
+	public static Object invokeMethod(Method method, Object target, Object... args) throws Throwable {
 		Preconditions.notNull(method, "method must not be null");
 		Preconditions.condition((target != null || Modifier.isStatic(method.getModifiers())),
 			() -> String.format("Cannot invoke non-static method [%s] on a null target.", method.toGenericString()));
@@ -383,7 +383,7 @@ public final class ReflectionUtils {
 		}
 	}
 
-	private static void handleException(Throwable ex) {
+	private static void handleException(Throwable ex) throws Throwable {
 		if (ex instanceof InvocationTargetException) {
 			handleException(((InvocationTargetException) ex).getTargetException());
 		}
@@ -405,23 +405,7 @@ public final class ReflectionUtils {
 		if (ex instanceof Error) {
 			throw (Error) ex;
 		}
-		// TODO Research if throwing the exception itself would be a better option
-		throw new TargetExceptionWrapper(ex);
-	}
-
-	public static class TargetExceptionWrapper extends RuntimeException {
-
-		private static final long serialVersionUID = 3733792088719661853L;
-
-		private final Throwable targetException;
-
-		private TargetExceptionWrapper(Throwable targetException) {
-			this.targetException = targetException;
-		}
-
-		public Throwable getTargetException() {
-			return targetException;
-		}
+		throw ex;
 	}
 
 }

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionConfigurationException.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionConfigurationException.java
@@ -16,6 +16,10 @@ package org.junit.gen5.api.extension;
 @SuppressWarnings("serial")
 public class ExtensionConfigurationException extends RuntimeException {
 
+	public ExtensionConfigurationException(Throwable cause) {
+		super(cause);
+	}
+
 	public ExtensionConfigurationException(String message) {
 		super(message);
 	}

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/MethodParameterResolver.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/MethodParameterResolver.java
@@ -51,7 +51,7 @@ public interface MethodParameterResolver extends ExtensionPoint {
 	 * @see ReflectionUtils#newInstance(Class, Object...)
 	 */
 	default Object resolve(Parameter parameter, MethodContext methodContext, ExtensionContext extensionContext)
-			throws ParameterResolutionException {
+			throws Throwable {
 
 		return ReflectionUtils.newInstance(parameter.getType());
 	}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/MethodTestDescriptor.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/MethodTestDescriptor.java
@@ -140,9 +140,6 @@ public class MethodTestDescriptor extends JUnit5TestDescriptor implements Leaf<J
 				testExtensionContext.getTestMethod());
 			new MethodInvoker(testExtensionContext, testExtensionRegistry).invoke(methodContext);
 		}
-		catch (ReflectionUtils.TargetExceptionWrapper wrapper) {
-			throwablesCollector.add(wrapper.getTargetException());
-		}
 		catch (Throwable t) {
 			throwablesCollector.add(t);
 		}
@@ -153,9 +150,6 @@ public class MethodTestDescriptor extends JUnit5TestDescriptor implements Leaf<J
 		ThrowingConsumer<RegisteredExtensionPoint<AfterEachExtensionPoint>> applyAfterEach = registeredExtensionPoint -> {
 			try {
 				registeredExtensionPoint.getExtensionPoint().afterEach(testExtensionContext);
-			}
-			catch (ReflectionUtils.TargetExceptionWrapper wrapper) {
-				throwablesCollector.add(wrapper.getTargetException());
 			}
 			catch (Throwable t) {
 				throwablesCollector.add(t);

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/MethodInvoker.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/MethodInvoker.java
@@ -42,7 +42,7 @@ public class MethodInvoker {
 		this.extensionRegistry = extensionRegistry;
 	}
 
-	public Object invoke(MethodContext methodContext) {
+	public Object invoke(MethodContext methodContext) throws Throwable {
 		return ReflectionUtils.invokeMethod(methodContext.getMethod(), methodContext.getInstance(),
 			resolveParameters(methodContext));
 	}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/TestExtensionRegistry.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/TestExtensionRegistry.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import org.junit.gen5.api.extension.ExtensionConfigurationException;
 import org.junit.gen5.api.extension.ExtensionPoint;
 import org.junit.gen5.api.extension.ExtensionPoint.Position;
 import org.junit.gen5.api.extension.ExtensionRegistrar;
@@ -146,7 +147,13 @@ public class TestExtensionRegistry {
 		boolean extensionExists = getRegisteredExtensionClasses().stream().anyMatch(
 			registeredClass -> registeredClass.equals(extensionClass));
 		if (!extensionExists) {
-			TestExtension testExtension = ReflectionUtils.newInstance(extensionClass);
+			TestExtension testExtension = null;
+			try {
+				testExtension = ReflectionUtils.newInstance(extensionClass);
+			}
+			catch (Throwable throwable) {
+				throw new ExtensionConfigurationException(throwable);
+			}
 			registerExtensionPointImplementors(testExtension);
 			registerFromExtensionRegistrar(testExtension);
 			this.registeredExtensionClasses.add(extensionClass);


### PR DESCRIPTION
Gets rid of Wrapper exception and a couple of catch clauses, but also requires (at least for reasons of symmetry) that ReflectionUtils.newInstance() throws Throwable.