### PR TITLE
Executable.execute() should allow throwing Throwable

### DIFF
--- a/junit5-api/src/main/java/org/junit/gen5/api/Executable.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/Executable.java
@@ -13,10 +13,10 @@ package org.junit.gen5.api;
 /**
  * {@code Executable} is a functional interface that can be used to
  * implement any generic block of code that potentially throws an
- * {@link Exception}.
+ * {@link Throwable}.
  *
  * <p>The {@code Executable} interface is similar to {@link java.lang.Runnable},
- * except that an {@code Executable} can throw an {@link Exception}.
+ * except that an {@code Executable} can throw an {@link Throwable}.
  *
  * @since 5.0
  * @see Assertions#assertAll(Executable...)
@@ -27,6 +27,6 @@ package org.junit.gen5.api;
 @FunctionalInterface
 public interface Executable {
 
-	void execute() throws Exception;
+	void execute() throws Throwable;
 
 }


### PR DESCRIPTION
`Assertions.assertThrows()` also allows for `Throwable` classes to be checked for:
https://github.com/junit-team/junit-lambda/blob/8a6a13c58d9e4a5f734037cdb088902364d1ba43/junit5-api/src/main/java/org/junit/gen5/api/Assertions.java#L204

Thus, `Throwable` must be the declared type on this `execute()` method.

This is particularyl interesting for Scala usage, where (I believe) exceptions derive from `Throwable`, not from `Exception`